### PR TITLE
add code + bpb eval config

### DIFF
--- a/src/cookbook/cli/cli.py
+++ b/src/cookbook/cli/cli.py
@@ -383,6 +383,7 @@ def convert(
     default=0,
     help="Set batch size for inference; if 0, use default batch size",
 )
+@click.option("--compute-gold-bpb", is_flag=True, help="Compute perplexity over the gold continuation for generative benchmarks (e.g., GSM, Minerva, HumanEval)", default=False)
 @click.option(
     "-o",
     "--remote-output-prefix",
@@ -411,6 +412,12 @@ def convert(
     default=False,
 )
 @click.option(
+    "--gpu-memory-utilization",
+    type=float,
+    default=None,
+    help="Reduce memory utilization for vLLM, defaults to 0.8",
+)
+@click.option(
     "--env-name",
     type=str,
     default="oe-eval-venv",
@@ -425,6 +432,7 @@ def evaluate(
     cluster: str,
     huggingface_secret: str,
     add_bos_token: bool,
+    compute_gold_bpb: bool,
     budget: str,
     priority: str,
     num_gpus: int,
@@ -440,6 +448,7 @@ def evaluate(
     use_gantry: bool,
     gantry_args: str,
     force_venv: bool,
+    gpu_memory_utilization: float,
     env_name: str,
 ):
     """Evaluate a checkpoint using the oe-eval toolkit.
@@ -456,6 +465,7 @@ def evaluate(
         cluster=cluster,
         huggingface_secret=huggingface_secret,
         add_bos_token=add_bos_token,
+        compute_gold_bpb=compute_gold_bpb,
         budget=budget,
         priority=priority,
         num_gpus=num_gpus,
@@ -470,6 +480,7 @@ def evaluate(
         beaker_image=beaker_image,
         use_gantry=use_gantry,
         gantry_args=gantry_args,
+        gpu_memory_utilization=gpu_memory_utilization,
         env=PythonEnv.create(name=env_name, force=force_venv),
     )
 

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -192,6 +192,7 @@ ALL_NAMED_GROUPS = {
     "gen": ALL_GEN_TASKS,
     "gen-no-jp": [task for task in ALL_GEN_TASKS if task != "jeopardy::olmes"],
     "code": ALL_CODEX_TASKS,
+    "code-no-bcb": [task for task in ALL_CODEX_TASKS if "bigcodebench" not in task],
 }
 
 OE_EVAL_GIT_URL = "git@github.com:allenai/oe-eval-internal.git"

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -156,7 +156,33 @@ ALL_GEN_TASKS = [
     "gsm8k::olmo1",
 ]
 
-ALL_CODEX_TASKS = []
+
+ALL_MATH_TASKS = [
+    # Held-out
+    # "minerva_math_algebra::olmes",
+    # "minerva_math_counting_and_probability::olmes",
+    # "minerva_math_geometry::olmes",
+    # "minerva_math_intermediate_algebra::olmes",
+    # "minerva_math_number_theory::olmes",
+    # "minerva_math_prealgebra::olmes",
+    # "minerva_math_precalculus::olmes",
+    # 'deepmind_math_large::none',
+    # 'gsm_plus::none',
+    # 'gsm_symbolic::none',
+    # 'gsm_symbolic_p1::none',
+    # 'gsm_symbolic_p2::none',
+    # 'minerva_math_500::none', 
+]
+
+
+ALL_CODEX_TASKS = [
+    "codex_humaneval:temp0.8",
+    "codex_humanevalplus:temp0.8", 
+    "mbpp::none",
+    "mbppplus::none",
+    "bigcodebench::none",
+    "bigcodebench_hard::none"
+]
 
 ALL_NAMED_GROUPS = {
     "mmlu:rc": [f"{category}:rc::olmes" for category in MMLU_CATEGORIES],
@@ -165,6 +191,7 @@ ALL_NAMED_GROUPS = {
     "core:mc": [f"{task}:mc::olmes" for task in ALL_CORE_TASKS],
     "gen": ALL_GEN_TASKS,
     "gen-no-jp": [task for task in ALL_GEN_TASKS if task != "jeopardy::olmes"],
+    "code": ALL_CODEX_TASKS,
 }
 
 OE_EVAL_GIT_URL = "git@github.com:allenai/oe-eval-internal.git"

--- a/src/cookbook/eval/checkpoints.py
+++ b/src/cookbook/eval/checkpoints.py
@@ -38,6 +38,7 @@ def evaluate_checkpoint(
     cluster: str,
     huggingface_secret: str,
     add_bos_token: bool,
+    compute_gold_bpb: bool,
     budget: str,
     priority: str,
     num_gpus: int,
@@ -52,6 +53,7 @@ def evaluate_checkpoint(
     beaker_image: str,
     use_gantry: bool,
     gantry_args: str,
+    gpu_memory_utilization: float,
     env: PythonEnv,
 ):
     # Install oe-eval toolkit
@@ -131,8 +133,9 @@ def evaluate_checkpoint(
     flags.append("--push-datalake")
 
     # set model info
+    gpu_memory_utilization = f',gpu_memory_utilization={gpu_memory_utilization}' if gpu_memory_utilization else ''
     flags.append(f"--model {run_name}")
-    flags.append(f"--model-args 'model_path={checkpoint_path},add_bos_token={add_bos_token}'")
+    flags.append(f"--model-args 'model_path={checkpoint_path},add_bos_token={add_bos_token}{gpu_memory_utilization}'")
     flags.append(f"--model-type {model_backend}")
 
     all_tasks = sorted(
@@ -168,6 +171,10 @@ def evaluate_checkpoint(
 
         # set extra arguments
         flags.append(extra_args)
+
+        # set compute gold bpb
+        if compute_gold_bpb:
+            flags.append(f"--task-args compute_gold_bpb=true")
 
         # set batch size
         if batch_size:


### PR DESCRIPTION
Here is the setup I'm using for code and generative evals:

```sh
# setup on vllm
olmo-cookbook evaluate \
  "bigcode/gpt_bigcode-santacoder" \
  -t code -t gen \
  --priority high \
  --cluster aus80g \
  --num-gpus 1 \
  --model-backend vllm \
  --compute-gold-bpb \
  --gpu-memory-utilization 0.6 \
  --remote-output-prefix s3://ai2-llm/evaluation/davidh-debug \
  --dashboard davidh-debug

# setup on hf
olmo-cookbook evaluate \
  "/oe-training-default/ai2-llm/checkpoints/ai2-tylerm/olmo2-7b-anneal-1b-ffb305c5-0000/step476-hf" \
  -t code -t gen \
  --priority high \
  --cluster aus80g \
  --num-gpus 1 \
  --model-backend hf \
  --compute-gold-bpb \
  --batch-size 8 \
  --remote-output-prefix s3://ai2-llm/evaluation/davidh-debug \
  --dashboard davidh-debug
```

Two notes on this: 
1. The flag `--compute-gold-bpb` is needed to compute BPB (this is a separate flag in oe-eval since it adds another forward pass for perplexity) 
2. the `--gpu-memory-utilization 0.6` changes the vLLM memory use (we've noticed for some >7B models, vLLM will throw OOM errors when calculating perplexity)

Trial beaker job here: https://beaker.allen.ai/orgs/ai2/workspaces/oe-data/work/01JMMR3AF5TPYG628NXXG9EA9F?taskId=01JMMR3AGEFGCJCTYX7VEYQFEW&jobId=01JMMR3AM6X65V15A9Y1JKZYQX