### PR TITLE
infilling tasks with model-specific tokens

### DIFF
--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -227,7 +227,7 @@ INFILLING_DEEPSEEK_CODER = [
     json.dumps({**MULTI_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
     json.dumps({**RANDOM_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
 ]
-INFILLING_TOKEN_TYPES = {
+FIM_TOKEN_TYPES = {
     "santacoder": INFILLING_SANTACODER,
     "starcoder": INFILLING_STARCODER,
     "deepseek-coder": INFILLING_DEEPSEEK_CODER,
@@ -245,7 +245,7 @@ ALL_NAMED_GROUPS = {
     "starcoder": STARCODER_CODEX_TASKS,
     "starcoder::pass@1": STARCODER_PASS_AT_1_TASKS,
     "code-no-bcb": [task for task in ALL_CODEX_TASKS if "bigcodebench" not in task],
-    **{f"infilling-{name}": tasks for name, tasks in INFILLING_TOKEN_TYPES.items()},
+    **{f"fim-{name}": tasks for name, tasks in FIM_TOKEN_TYPES.items()},
 }
 
 OE_EVAL_GIT_URL = "git@github.com:allenai/oe-eval-internal.git"

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -192,12 +192,16 @@ STARCODER_PASS_AT_1_TASKS = [
 
 STARCODER_INFILLING = {
     "context_kwargs": {"lead_token": "<fim_prefix>", "center_token": "<fim_suffix>", "end_token": "<fim_middle>"},
-    "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"]},
+    "generation_kwargs": {
+        "stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"],
+    },
 }
 
 SANTACODER_INFILLING = {
     "context_kwargs": {"lead_token": "<fim-prefix>", "center_token": "<fim-suffix>", "end_token": "<fim-middle>"},
-    "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"]},
+    "generation_kwargs": {
+        "stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"],
+    },
 }
 
 DEEPSEEK_CODER_INFILLING = {
@@ -223,6 +227,11 @@ INFILLING_DEEPSEEK_CODER = [
     json.dumps({**MULTI_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
     json.dumps({**RANDOM_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
 ]
+INFILLING_TOKEN_TYPES = {
+    "santacoder": INFILLING_SANTACODER,
+    "starcoder": INFILLING_STARCODER,
+    "deepseek-coder": INFILLING_DEEPSEEK_CODER,
+}
 
 ALL_NAMED_GROUPS = {
     "mmlu:rc": [f"{category}:rc::olmes" for category in MMLU_CATEGORIES],
@@ -236,9 +245,7 @@ ALL_NAMED_GROUPS = {
     "starcoder": STARCODER_CODEX_TASKS,
     "starcoder::pass@1": STARCODER_PASS_AT_1_TASKS,
     "code-no-bcb": [task for task in ALL_CODEX_TASKS if "bigcodebench" not in task],
-    "infilling-starcoder": INFILLING_STARCODER,
-    "infilling-santacoder": INFILLING_SANTACODER,
-    "infilling-deepseek-coder": INFILLING_DEEPSEEK_CODER,
+    **{f"infilling-{name}": tasks for name, tasks in INFILLING_TOKEN_TYPES.items()},
 }
 
 OE_EVAL_GIT_URL = "git@github.com:allenai/oe-eval-internal.git"

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -1,3 +1,5 @@
+import json
+
 TRANSFORMERS_GIT_URL = "https://github.com/huggingface/transformers.git"
 TRANSFORMERS_COMMIT_HASH = "241c04d36867259cdf11dbb4e9d9a60f9cb65ebc"  # v4.47.1
 
@@ -188,6 +190,40 @@ STARCODER_PASS_AT_1_TASKS = [
     "mbpp::starcoder_pass@1",
 ]
 
+STARCODER_INFILLING = {
+    "context_kwargs": {"lead_token": "<fim_prefix>", "center_token": "<fim_suffix>", "end_token": "<fim_middle>"},
+    "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"]},
+}
+
+SANTACODER_INFILLING = {
+    "context_kwargs": {"lead_token": "<fim-prefix>", "center_token": "<fim-suffix>", "end_token": "<fim-middle>"},
+    "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|filename|>", "<file_sep>"]},
+}
+
+DEEPSEEK_CODER_INFILLING = {
+    "context_kwargs": {"lead_token": "<｜fim▁begin｜>", "center_token": "<｜fim▁hole｜>", "end_token": "<｜fim▁end｜>"},
+    "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|EOT|>"]},
+}
+
+SINGLE_FIM_TASK = {"task_name": "codex_humanevalfim_single:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
+MULTI_FIM_TASK = {"task_name": "codex_humanevalfim_multi:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
+RANDOM_FIM_TASK = {"task_name": "codex_humanevalfim_random:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
+INFILLING_STARCODER = [
+    json.dumps({**SINGLE_FIM_TASK, **STARCODER_INFILLING}),
+    json.dumps({**MULTI_FIM_TASK, **STARCODER_INFILLING}),
+    json.dumps({**RANDOM_FIM_TASK, **STARCODER_INFILLING}),
+]
+INFILLING_SANTACODER = [
+    json.dumps({**SINGLE_FIM_TASK, **SANTACODER_INFILLING}),
+    json.dumps({**MULTI_FIM_TASK, **SANTACODER_INFILLING}),
+    json.dumps({**RANDOM_FIM_TASK, **SANTACODER_INFILLING}),
+]
+INFILLING_DEEPSEEK_CODER = [
+    json.dumps({**SINGLE_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
+    json.dumps({**MULTI_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
+    json.dumps({**RANDOM_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
+]
+
 ALL_NAMED_GROUPS = {
     "mmlu:rc": [f"{category}:rc::olmes" for category in MMLU_CATEGORIES],
     "mmlu:mc": [f"{category}:mc::olmes" for category in MMLU_CATEGORIES],
@@ -200,6 +236,9 @@ ALL_NAMED_GROUPS = {
     "starcoder": STARCODER_CODEX_TASKS,
     "starcoder::pass@1": STARCODER_PASS_AT_1_TASKS,
     "code-no-bcb": [task for task in ALL_CODEX_TASKS if "bigcodebench" not in task],
+    "infilling-starcoder": INFILLING_STARCODER,
+    "infilling-santacoder": INFILLING_SANTACODER,
+    "infilling-deepseek-coder": INFILLING_DEEPSEEK_CODER,
 }
 
 OE_EVAL_GIT_URL = "git@github.com:allenai/oe-eval-internal.git"

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -1,3 +1,4 @@
+import json
 import re
 import shlex
 import subprocess
@@ -166,7 +167,9 @@ def evaluate_checkpoint(
 
             # add all tasks in the partition as flag
             partition_tasks = tasks_names[i : i + partition_size] if partition_size else tasks_names
-            local_flags.append(f"--task {' '.join(partition_tasks)}")
+            escaped_partition_tasks = [json.dumps(task) if task[0] == "{" else task for task in partition_tasks]
+
+            local_flags.append(f"--task {' '.join(escaped_partition_tasks)}")
 
             if add_aws_flags(
                 aws_access_key_id=aws_access_key_id,


### PR DESCRIPTION
This handles the model-specific tokens for infilling used in the prompt for the HumanEval-FIM suite of tasks. Model-specific stop sequences also affect model score on this task.

This treatment of the json tasks is handled successfully by the parsing code in oe-eval [here](https://github.com/allenai/oe-eval-internal/blob/main/oe_eval/utils.py#L111-L136).

Sample deepseek run can be seen here: https://beaker.org/ex/01JQ7CDHMNGYS2HYZ47XK8M0X8
(I commented out multi for this test run because it is a larger dataset and longer runtime).
```
olmo-cookbook-eval evaluate deepseek-ai/deepseek-coder-6.7b-base --tasks infilling-deepseek-coder --priority normal --cluster a100 --num-gpus 1 --model-backend vllm
```

```
{
  "all_primary_scores": [
    "codex_humanevalfim_random: 0.757317",
    "codex_humanevalfim_single: 0.871249"
  ],
  "model_config": {
    "gpu_memory_utilization": 0.8,
    "model": "deepseek-coder-6.7b-base",
    "model_path": "deepseek-ai/deepseek-coder-6.7b-base",
    "model_type": "vllm"
  },
  "tasks": [
    {
      "alias": "codex_humanevalfim_random",
      "metrics": {
        "acc_per_byte": 1,
        "acc_per_char": 1,
        "acc_per_token": 1,
        "acc_raw": 1,
        "bits_per_byte_corr": 0.9947905781364782,
        "logits_per_char_corr": -0.6895362844824019,
        "logits_per_token_corr": -1.4878222251917805,
        "pass_at_1": 0.7573170731707317,
        "primary_score": 0.7573170731707317,
        "sum_logits_corr": -13.611232692337458
      },
      "num_instances": 1640,
      "processing_time": 133.58312511444092,
      "task_config": {
        "compute_gold_bpb": true,
        "context_kwargs": {
          "center_token": "<｜fim▁hole｜>",
          "end_token": "<｜fim▁end｜>",
          "lead_token": "<｜fim▁begin｜>"
        },
        "dataset_name": "HumanEval-RandomSpanInfilling",
        "dataset_path": "loubnabnl/humaneval_infilling",
        "generation_kwargs": {
          "do_sample": true,
          "max_gen_toks": 512,
          "repeats": 1,
          "stop_sequences": [
            "<|eot_id|>",
            "<|endoftext|>",
            "<|EOT|>"
          ],
          "temperature": 0.2,
          "top_p": 0.95
        },
        "metadata": {
          "regimes": []
        },
        "metric_kwargs": {
          "n_exe_workers": 20,
          "pass_at_ks": [
            1
          ]
        },
        "native_id_field": "task_id",
        "primary_metric": "pass_at_1",
        "split": "test",
        "task_core": "codex_humanevalfim_random",
        "task_name": "codex_humanevalfim_random",
        "version": 0.1
      }
    },
    {
      "alias": "codex_humanevalfim_single",
      "metrics": {
        "acc_per_byte": 1,
        "acc_per_char": 1,
        "acc_per_token": 1,
        "acc_raw": 1,
        "bits_per_byte_corr": 0.09861678160672571,
        "logits_per_char_corr": -0.06835594412654873,
        "logits_per_token_corr": -0.18876305522419387,
        "pass_at_1": 0.8712487899322362,
        "primary_score": 0.8712487899322362,
        "sum_logits_corr": -2.150534953841365
      },
      "num_instances": 1033,
      "processing_time": 88.74508094787598,
      "task_config": {
        "compute_gold_bpb": true,
        "context_kwargs": {
          "center_token": "<｜fim▁hole｜>",
          "end_token": "<｜fim▁end｜>",
          "lead_token": "<｜fim▁begin｜>"
        },
        "dataset_name": "HumanEval-SingleLineInfilling",
        "dataset_path": "loubnabnl/humaneval_infilling",
        "generation_kwargs": {
          "do_sample": true,
          "max_gen_toks": 512,
          "repeats": 1,
          "stop_sequences": [
            "<|eot_id|>",
            "<|endoftext|>",
            "<|EOT|>"
          ],
          "temperature": 0.2,
          "top_p": 0.95
        },
        "metadata": {
          "regimes": []
        },
        "metric_kwargs": {
          "n_exe_workers": 20,
          "pass_at_ks": [
            1
          ]
        },
        "native_id_field": "task_id",
        "primary_metric": "pass_at_1",
        "split": "test",
        "task_core": "codex_humanevalfim_single",
        "task_name": "codex_humanevalfim_single",
        "version": 0.1
      }
    }
  ]
}
```