### PR TITLE
add all-splits

### DIFF
--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -250,6 +250,8 @@ ALL_NAMED_GROUPS = {
     "mmlu:mc": [f"{category}:mc::olmes" for category in MMLU_CATEGORIES],
     "core:rc": [f"{task}:rc::olmes" for task in ALL_CORE_TASKS],
     "core:mc": [f"{task}:mc::olmes" for task in ALL_CORE_TASKS],
+    "core-all-splits:rc": [f"{task}:rc::all_splits" for task in ALL_CORE_TASKS],
+    "core-all-splits:mc": [f"{task}:mc::all_splits" for task in ALL_CORE_TASKS],
     "gen": ALL_GEN_TASKS,
     "gen-no-jp": [task for task in ALL_GEN_TASKS if task != "jeopardy::olmes"],
     "minerva": ALL_MINERVA_TASKS,


### PR DESCRIPTION
Add config corresponding to larger splits from https://github.com/allenai/oe-eval-internal/pull/458.

The `core-all-splits` uses train, test, and val splits for OLMES tasks, with 2x-10x the number of instances from original OLMES. Runtime will be slower but rank will be more stable.

**Will not merge until upstream PR is approved.**