### PR TITLE
tweak resulting from tweaks

### DIFF
--- a/src/cookbook/model/builder.py
+++ b/src/cookbook/model/builder.py
@@ -340,7 +340,7 @@ class TransformerConfigBuilder:
                 )
             else:
                 evaluators = DownstreamEvaluatorCallbackConfig(
-                    tasks=[evaluator.value for evaluator in self.downstream_evaluators],
+                    tasks=[evaluator for evaluator in self.downstream_evaluators],
                     tokenizer=self.tokenizer,
                     eval_interval=self.eval_interval,
                 )


### PR DESCRIPTION
I believe this is needed as a counterpart to the changes in the DownstreamEvaluator enum, otherwise throws `AttributeError: 'str' object has no attribute 'value'` in model/builder.py/build_callbacks

https://github.com/allenai/olmo-cookbook/pull/51/files#diff-e2a22371edfb6373f6ad9d476410123810b4117add478df7e44c1f06b24be7ec