### PR TITLE
Cookbook fim revisited

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -199,7 +199,7 @@ def convert_checkpoint(
     default=get_aws_secret_access_key(),
     help="AWS secret access key to use for S3 access",
 )
-@click.option("-l", "--gantry-args", type=str, default="", help="Extra arguments to pass to Gantry")
+@click.option("-l", "--gantry-args", type=str, default="{}", help="Extra arguments to pass to Gantry")
 @click.option("-i", "--beaker-image", type=str, default=None, help="Beaker image to use for evaluation")
 @click.option(
     "-z",

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -200,7 +200,7 @@ def convert_checkpoint(
     default=get_aws_secret_access_key(),
     help="AWS secret access key to use for S3 access",
 )
-@click.option("-l", "--gantry-args", type=str, default="{}", help="Extra arguments to pass to Gantry")
+@click.option("-l", "--gantry-args", type=str, default="", help="Extra arguments to pass to Gantry")
 @click.option("-i", "--beaker-image", type=str, default=None, help="Beaker image to use for evaluation")
 @click.option(
     "-z",

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -21,6 +21,7 @@ from cookbook.constants import (
     OLMO_TYPES,
     OLMOE_COMMIT_HASH,
     TRANSFORMERS_COMMIT_HASH,
+    FIM_TOKENS,
 )
 from cookbook.eval.conversion import run_checkpoint_conversion
 from cookbook.eval.datalake import AddToDashboard, FindExperiments, RemoveFromDashboard
@@ -266,6 +267,12 @@ def convert_checkpoint(
     help="Extra arguments to pass to the model",
 )
 @click.option(
+    "--fim-tokens",
+    type=click.Choice(list(FIM_TOKENS.keys())),
+    default=None,
+    help="Model-specific tokens to use for infilling tasks",
+)
+@click.option(
     "--vllm-use-v1-spec/--no-vllm-use-v1-spec",
     default=False,
     type=bool,
@@ -306,6 +313,7 @@ def evaluate_model(
     vllm_for_mc: bool,
     compute_gold_bpb: bool,
     model_args: str,
+    fim_tokens: str,
     vllm_use_v1_spec: bool,
     use_backend_in_run_name: bool,
 ):
@@ -353,6 +361,7 @@ def evaluate_model(
         vllm_for_mc=vllm_for_mc,
         compute_gold_bpb=compute_gold_bpb,
         model_args=parsed_model_args,
+        fim_tokens=fim_tokens,
         use_vllm_v1_spec=vllm_use_v1_spec,
         use_backend_in_run_name=use_backend_in_run_name,
     )

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -406,8 +406,6 @@ STARCODER_PASS_AT_1_TASKS = [
     "mbpp::starcoder_pass@1",
 ]
 
-
-
 STARCODER_INFILLING = {
     "context_kwargs": {"lead_token": "<fim_prefix>", "center_token": "<fim_suffix>", "end_token": "<fim_middle>"},
     "generation_kwargs": {
@@ -440,14 +438,10 @@ L2C_INFILLING = {
 
 FIM_TOKENS = {"santacoder": SANTACODER_INFILLING, "starcoder": STARCODER_INFILLING, "deepseek": DEEPSEEK_CODER_INFILLING, "l2c": L2C_INFILLING}
 
-# FIM_TASKS = [
-#     "codex_humanevalfim_single:temp0.2",
-#     "codex_humanevalfim_multi:temp0.2",
-#     "codex_humanevalfim_random:temp0.2"
-# ]
-
 FIM_TASKS = [
     "codex_humanevalfim_single:temp0.2",
+    "codex_humanevalfim_multi:temp0.2",
+    "codex_humanevalfim_random:temp0.2"
 ]
 
 

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -406,6 +406,8 @@ STARCODER_PASS_AT_1_TASKS = [
     "mbpp::starcoder_pass@1",
 ]
 
+
+
 STARCODER_INFILLING = {
     "context_kwargs": {"lead_token": "<fim_prefix>", "center_token": "<fim_suffix>", "end_token": "<fim_middle>"},
     "generation_kwargs": {
@@ -429,32 +431,20 @@ DEEPSEEK_CODER_INFILLING = {
     "generation_kwargs": {"stop_sequences": ["<|eot_id|>", "<|endoftext|>", "<|EOT|>"]},
 }
 
-SINGLE_FIM_TASK = {"task_name": "codex_humanevalfim_single:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
-MULTI_FIM_TASK = {"task_name": "codex_humanevalfim_multi:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
-RANDOM_FIM_TASK = {"task_name": "codex_humanevalfim_random:temp0.2", "metric_kwargs": {"n_exe_workers": 20}}
-INFILLING_STARCODER = [
-    json.dumps({**SINGLE_FIM_TASK, **STARCODER_INFILLING}),
-    json.dumps({**MULTI_FIM_TASK, **STARCODER_INFILLING}),
-    json.dumps({**RANDOM_FIM_TASK, **STARCODER_INFILLING}),
-]
-INFILLING_SANTACODER = [
-    json.dumps({**SINGLE_FIM_TASK, **SANTACODER_INFILLING}),
-    json.dumps({**MULTI_FIM_TASK, **SANTACODER_INFILLING}),
-    json.dumps({**RANDOM_FIM_TASK, **SANTACODER_INFILLING}),
-]
-INFILLING_DEEPSEEK_CODER = [
-    json.dumps({**SINGLE_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
-    json.dumps({**MULTI_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
-    json.dumps({**RANDOM_FIM_TASK, **DEEPSEEK_CODER_INFILLING}),
-]
-FIM_TOKEN_TYPES = {
-    "santacoder": INFILLING_SANTACODER,
-    "starcoder": INFILLING_STARCODER,
-    "deepseek-coder": INFILLING_DEEPSEEK_CODER,
+L2C_INFILLING = {
+    "context_kwargs": {"lead_token": "<|fim_prefix|>", "center_token": "<|fim_suffix|>", "end_token": "<|fim_middle|>"},
+    "generation_kwargs": {
+        "stop_sequences": ["<|endoftext|>", "<|filename|>", "<file_sep>"],
+    },
 }
 
-# TODO: clean up such that tasks kwargs are separate from task aliases.
-FIM_TASKS = {f"fim-{name}": tasks for name, tasks in FIM_TOKEN_TYPES.items()}
+FIM_TOKENS = {"santacoder": SANTACODER_INFILLING, "starcoder": STARCODER_INFILLING, "deepseek": DEEPSEEK_CODER_INFILLING, "l2c": L2C_INFILLING}
+
+FIM_TASKS = [
+    "codex_humanevalfim_single:temp0.2",
+    "codex_humanevalfim_multi:temp0.2",
+    "codex_humanevalfim_random:temp0.2"
+]
 
 
 # named groups are things you should able to average; they
@@ -475,6 +465,7 @@ ALL_NAMED_GROUPS = {
     "starcoder": STARCODER_CODEX_TASKS,
     "starcoder::pass@1": STARCODER_PASS_AT_1_TASKS,
     "code-no-bcb": [task for task in ALL_CODEX_TASKS if "bigcodebench" not in task],
+    "fim": FIM_TASKS
 }
 
 for helmet_length in (int(2**i) for i in range(13, 18)):

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -434,16 +434,20 @@ DEEPSEEK_CODER_INFILLING = {
 L2C_INFILLING = {
     "context_kwargs": {"lead_token": "<|fim_prefix|>", "center_token": "<|fim_suffix|>", "end_token": "<|fim_middle|>"},
     "generation_kwargs": {
-        "stop_sequences": ["<|endoftext|>", "<|filename|>", "<file_sep>"],
+        "stop_sequences": ["<|endoftext|>", "<|filename|>", "<|file_sep|>"],
     },
 }
 
 FIM_TOKENS = {"santacoder": SANTACODER_INFILLING, "starcoder": STARCODER_INFILLING, "deepseek": DEEPSEEK_CODER_INFILLING, "l2c": L2C_INFILLING}
 
+# FIM_TASKS = [
+#     "codex_humanevalfim_single:temp0.2",
+#     "codex_humanevalfim_multi:temp0.2",
+#     "codex_humanevalfim_random:temp0.2"
+# ]
+
 FIM_TASKS = [
     "codex_humanevalfim_single:temp0.2",
-    "codex_humanevalfim_multi:temp0.2",
-    "codex_humanevalfim_random:temp0.2"
 ]
 
 

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -245,12 +245,15 @@ def evaluate_checkpoint(
             if model_backend == "vllm" and task_group == "mc" and vllm_for_mc:
                 local_flags.append("--vllm-for-mc")
 
-            if compute_gold_bpb:
-                local_flags.append("--task-args compute_gold_bpb=true")
-            
+            special_task_args = {}
             if fim_tokens:
-                special_tokens_dict = FIM_TOKENS[fim_tokens]
-                local_flags.append(f"--task-args '{json.dumps(special_tokens_dict)}'")
+                special_task_args = FIM_TOKENS[fim_tokens]
+
+            if compute_gold_bpb:
+                special_task_args["compute_gold_bpb"] = True
+            
+            if special_task_args:
+                local_flags.append(f"--task-args '{json.dumps(special_task_args)}'")
 
             # run oe-eval
             cmd = f"{env.python} {OE_EVAL_LAUNCH_COMMAND} {' '.join(local_flags)}"

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -19,6 +19,7 @@ from cookbook.constants import (
     BEAKER_KNOWN_CLUSTERS,
     OE_EVAL_LAUNCH_COMMAND,
     WEKA_MOUNTS,
+    FIM_TOKENS,
 )
 
 
@@ -51,6 +52,7 @@ def evaluate_checkpoint(
     vllm_for_mc: bool,
     compute_gold_bpb: bool,
     model_args: Optional[dict],
+    fim_tokens: str,
     use_vllm_v1_spec: bool,
     use_backend_in_run_name: bool,
 ):
@@ -245,6 +247,10 @@ def evaluate_checkpoint(
 
             if compute_gold_bpb:
                 local_flags.append("--task-args compute_gold_bpb=true")
+            
+            if fim_tokens:
+                special_tokens_dict = FIM_TOKENS[fim_tokens]
+                local_flags.append(f"--task-args '{json.dumps(special_tokens_dict)}'")
 
             # run oe-eval
             cmd = f"{env.python} {OE_EVAL_LAUNCH_COMMAND} {' '.join(local_flags)}"


### PR DESCRIPTION
Adds model-specific context and generation kwargs via task args override flag.

If both `--compute_gold_bpb` flag (default) and `--fim-tokens l2c` flag are set, will pass
```
--task-args '{"context_kwargs": {"lead_token": "<|fim_prefix|>", "center_token": "<|fim_suffix|>", "end_token": "<|fim_middle|>"}, "generation_kwargs": {"stop_sequences": ["<|endoftext|>", "<|filename|>", "<|file_sep|>"]}, "compute_gold_bpb": true}'
```

Within oe-eval, task-args are handled as overrides that are integrated with existing args for the task:
```
'python -m oe_eval.run_eval --task ''{"task_name": "codex_humanevalfim_multi",
    "primary_metric": "pass_at_1", "generation_kwargs": {"do_sample": true, "top_p":
    0.95, "temperature": 0.2, "stop_sequences": ["<|endoftext|>", "<|filename|>",
    "<|file_sep|>"]}, "metric_kwargs": {"pass_at_ks": [1], "n_exe_workers": 20, "rich_exec_info":
    true}, "metadata": {"regimes": [], "alias": "codex_humanevalfim_multi:temp0.2"},
    "context_kwargs": {"lead_token": "<|fim_prefix|>", "center_token": "<|fim_suffix|>",
    "end_token": "<|fim_middle|>"}, "compute_gold_bpb": true}''
```