### PR TITLE
docs: results --format json

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ You can also provide a list of `--tasks` to get results for specific tasks.
 
 You can also provide a list of `--models` regular expressions to filter the models by name.
 
+You can use `--format json` to see full results when model names are long.
+
 
 
 ## Running OLMo-core script

--- a/src/cookbook/recipes/olmo3-evals/README.md
+++ b/src/cookbook/recipes/olmo3-evals/README.md
@@ -49,7 +49,7 @@ olmo-cookbook-eval evaluate "/oe-training-default/ai2-llm/checkpoints/mayeec/olm
 *Task names are collected here: https://github.com/allenai/olmo-cookbook/blob/e20beaee74a6a10b18113520e9e907fdbc24f444/src/cookbook/constants.py#L478*
 
 
-To pull dashboard results:
+To pull dashboard results (use `--format json` to see full results):
 
 ```
 olmo-cookbook-eval results \


### PR DESCRIPTION
`olmo-cookbook-eval results` table output tends to truncate model names to the point of being unreadable. This can be easily solved by using `--format json` but this is not documented anywhere. This pre just adds references to this flag in a couple places to save the next people coming thru here the 5 mins it takes to find this flag.