### PR TITLE
Kyle/missing metrics log

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -290,6 +290,12 @@ def convert_checkpoint(
     default="",
     help="Suffix to add to the run name",
 )
+@click.option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress progress bars and info output."
+)
 def evaluate_model(
     oe_eval_commit: str,
     checkpoint_path: str,
@@ -323,6 +329,7 @@ def evaluate_model(
     vllm_use_v1_spec: bool,
     use_backend_in_run_name: bool,
     name_suffix: str,
+    quiet: bool,
 ):
     """Evaluate a checkpoint using the oe-eval toolkit.
     This command will launch a job on Beaker to evaluate the checkpoint using the specified parameters.
@@ -372,6 +379,7 @@ def evaluate_model(
         use_vllm_v1_spec=vllm_use_v1_spec,
         use_backend_in_run_name=use_backend_in_run_name,
         name_suffix=name_suffix,
+        quiet=quiet,
     )
 
 
@@ -425,6 +433,12 @@ def evaluate_model(
     is_flag=True,
     help="Skip experiments that fail to fetch results from the datalake",
 )
+@click.option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress progress bars and info output."
+)
 def get_results(
     dashboard: str,
     models: list[str],
@@ -435,6 +449,7 @@ def get_results(
     sort_descending: bool,
     force: bool,
     skip_on_fail: bool,
+    quiet: bool,
 ) -> None:
     all_metrics, all_averages, missing_by_model = make_dashboard_table(
         dashboard=dashboard,
@@ -448,6 +463,7 @@ def get_results(
         show_bpb=False,
         force=force,
         skip_on_fail=skip_on_fail,
+        quiet=quiet,
     )
 
     # if a task starts with *, it means it is a named group and we need to expand it

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -445,7 +445,7 @@ def get_results(
         average_mmlu=True,
         average_core=True,
         average_generative=True,
-        show_bpb=True,
+        show_bpb=False,
         force=force,
         skip_on_fail=skip_on_fail,
     )

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -436,7 +436,7 @@ def get_results(
     force: bool,
     skip_on_fail: bool,
 ) -> None:
-    all_metrics, all_averages, missing_by_model = make_dashboard_table(
+    tables = make_dashboard_table(
         dashboard=dashboard,
         show_rc=True,
         show_mc=True,
@@ -455,7 +455,7 @@ def get_results(
 
     # after that, we check for task patterns
     task_patterns = [re.compile(t_) for task in tasks for t_ in ALL_DISPLAY_TASKS.get(task, [task])]
-    results = (all_averages + all_metrics).keep_cols(*task_patterns)
+    results = (tables.averages + tables.metrics).keep_cols(*task_patterns)
 
     if len(models) > 0:
         results = results.keep_rows(*[re.compile(m) for m in models])
@@ -471,8 +471,8 @@ def get_results(
         # if no columns are left, we don't need to sort
         pass
 
-    if missing_by_model:
-        for model, missing_tasks in missing_by_model.items():
+    if tables.missing_tasks:
+        for model, missing_tasks in tables.missing_tasks.items():
             logger.warning(f"\t😱 Model {model} is missing tasks:\t\t{', '.join(missing_tasks)}")
         logger.warning("\n")
 

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -290,12 +290,6 @@ def convert_checkpoint(
     default="",
     help="Suffix to add to the run name",
 )
-@click.option(
-    "--quiet",
-    is_flag=True,
-    default=False,
-    help="Suppress progress bars and info output."
-)
 def evaluate_model(
     oe_eval_commit: str,
     checkpoint_path: str,
@@ -329,7 +323,6 @@ def evaluate_model(
     vllm_use_v1_spec: bool,
     use_backend_in_run_name: bool,
     name_suffix: str,
-    quiet: bool,
 ):
     """Evaluate a checkpoint using the oe-eval toolkit.
     This command will launch a job on Beaker to evaluate the checkpoint using the specified parameters.
@@ -379,7 +372,6 @@ def evaluate_model(
         use_vllm_v1_spec=vllm_use_v1_spec,
         use_backend_in_run_name=use_backend_in_run_name,
         name_suffix=name_suffix,
-        quiet=quiet,
     )
 
 
@@ -420,8 +412,8 @@ def evaluate_model(
     default="",
     help="Name of the column to sort by",
 )
-@click.option('-A/--ascending', 'sort_descending', flag_value=False, default=False, help="Sort ascending")
-@click.option('-D/--descending', 'sort_descending', flag_value=True, default=False, help="Sort descending")
+@click.option("-A/--ascending", "sort_descending", flag_value=False, default=False, help="Sort ascending")
+@click.option("-D/--descending", "sort_descending", flag_value=True, default=False, help="Sort descending")
 @click.option(
     "-F",
     "--force",
@@ -433,12 +425,6 @@ def evaluate_model(
     is_flag=True,
     help="Skip experiments that fail to fetch results from the datalake",
 )
-@click.option(
-    "--quiet",
-    is_flag=True,
-    default=False,
-    help="Suppress progress bars and info output."
-)
 def get_results(
     dashboard: str,
     models: list[str],
@@ -449,7 +435,6 @@ def get_results(
     sort_descending: bool,
     force: bool,
     skip_on_fail: bool,
-    quiet: bool,
 ) -> None:
     all_metrics, all_averages, missing_by_model = make_dashboard_table(
         dashboard=dashboard,
@@ -463,7 +448,6 @@ def get_results(
         show_bpb=False,
         force=force,
         skip_on_fail=skip_on_fail,
-        quiet=quiet,
     )
 
     # if a task starts with *, it means it is a named group and we need to expand it
@@ -480,7 +464,7 @@ def get_results(
         results = results.sort(
             by_col=((sort_column_name or next(iter(results.columns))) if sort_by.startswith("col") else None),
             by_name=sort_by.startswith("name"),
-            by_avg='avg' in sort_by or 'average' in sort_by,
+            by_avg="avg" in sort_by or "average" in sort_by,
             reverse=not sort_descending,
         )
     except StopIteration:

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -436,8 +436,7 @@ def get_results(
     force: bool,
     skip_on_fail: bool,
 ) -> None:
-
-    all_metrics, all_averages = make_dashboard_table(
+    all_metrics, all_averages, missing_by_model = make_dashboard_table(
         dashboard=dashboard,
         show_rc=True,
         show_mc=True,
@@ -446,7 +445,7 @@ def get_results(
         average_mmlu=True,
         average_core=True,
         average_generative=True,
-        show_bpb=False,
+        show_bpb=True,
         force=force,
         skip_on_fail=skip_on_fail,
     )
@@ -471,6 +470,11 @@ def get_results(
     except StopIteration:
         # if no columns are left, we don't need to sort
         pass
+
+    if missing_by_model:
+        for model, missing_tasks in missing_by_model.items():
+            logger.warning(f"\t😱 Model {model} is missing tasks:\t\t{', '.join(missing_tasks)}")
+        logger.warning("\n")
 
     if format == "json":
         print(json.dumps(results._data))

--- a/src/cookbook/eval/cache.py
+++ b/src/cookbook/eval/cache.py
@@ -3,7 +3,6 @@ import json
 import os
 import shutil
 from dataclasses import dataclass
-from dataclasses import field as dataclass_field
 from typing import Generic, TypeVar
 
 import smart_open

--- a/src/cookbook/eval/datalake.py
+++ b/src/cookbook/eval/datalake.py
@@ -7,15 +7,16 @@ from dataclasses import field as dataclass_field
 from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from functools import partial
+from sys import stderr
 from threading import current_thread, main_thread
 from typing import Callable, ClassVar, Generic, List, TypeVar
 
 import requests
 from tqdm import tqdm
+from typing_extensions import Self
 
-from cookbook.eval.cache import DatalakeCache, get_datalake_cache  # Change import
+from cookbook.eval.cache import get_datalake_cache
 
-Self = TypeVar("Self", bound="BaseDatalakeItem")
 T = TypeVar("T")
 V = TypeVar("V")
 
@@ -50,7 +51,7 @@ class BaseDatalakeItem(Generic[T]):
         with ExitStack() as stack:
             # Set up thread pool and progress bar
             pool = stack.enter_context(ThreadPoolExecutor(max_workers=num_workers))
-            pbar = stack.enter_context(tqdm(total=len(fns), desc=cls.__name__, disable=quiet))
+            pbar = stack.enter_context(tqdm(total=len(fns), desc=cls.__name__, disable=quiet, file=stderr))
 
             # Submit all tasks to the thread pool
             futures = [pool.submit(fn) for fn in fns]

--- a/src/cookbook/eval/datalake.py
+++ b/src/cookbook/eval/datalake.py
@@ -69,7 +69,7 @@ class BaseDatalakeItem(Generic[T]):
         return results
 
     @classmethod
-    def prun(cls, num_workers: int | None = None, **kwargs: list[T]) -> list[Self]:
+    def prun(cls, num_workers: int | None = None, quiet: bool = False, **kwargs: list[T]) -> list[Self]:
         """Same as run() method, but runs in parallel.
 
         Args:
@@ -90,7 +90,7 @@ class BaseDatalakeItem(Generic[T]):
         fns = [partial(cls.run, **{k: v[i] for k, v in kwargs.items()}) for i in range(num_args)]
 
         # actually run the function in parallel
-        results = cls._prun(fns=fns, num_workers=num_workers, quiet=False)
+        results = cls._prun(fns=fns, num_workers=num_workers, quiet=quiet)
         return [result for result_group in results for result in result_group]
 
 

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -44,7 +44,6 @@ def make_dashboard_table(
     force: bool = False,
     skip_on_fail: bool = False,
 ) -> tuple[MiniFrame, MiniFrame]:
-    dashboard = "alldressed_v1/dedup_ablations_v1_BLESSED"
     experiments = FindExperiments.run(dashboard=dashboard)
 
     logger.info(f"Found {len(experiments)} experiments in dashboard {dashboard}")

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -18,7 +18,7 @@ def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]
     unique_task_names = {metric.alias for metric in metrics if metric.alias is not None}
 
     # Check for missing task-model combinations
-    missing_by_model = {}
+    missing_by_model: dict[str, list[str]] = {}
     for model in unique_model_names:
         missing_tasks = []
         for task in unique_task_names:

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -8,14 +8,16 @@ from cookbook.eval.miniframe import MiniFrame
 
 logger = logging.getLogger(__name__)
 
+
 class DashboardTables(NamedTuple):
     all_metrics: MiniFrame
     avg_metrics: MiniFrame
     missing_by_model: dict[str, list[str]]
 
+
 def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]:
     """Validate that all models have completed all tasks and return missing combinations.
-    
+
     Returns:
         Dict mapping model names to lists of missing task names.
     """
@@ -35,6 +37,7 @@ def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]
 
     return missing_by_model
 
+
 def make_dashboard_table(
     dashboard: str,
     task_regex: str = r"^.*$",
@@ -49,7 +52,6 @@ def make_dashboard_table(
     show_partial: bool = True,
     force: bool = False,
     skip_on_fail: bool = False,
-    quiet: bool = False,
 ) -> DashboardTables:
     experiments = FindExperiments.run(dashboard=dashboard)
 
@@ -57,7 +59,7 @@ def make_dashboard_table(
 
     # these are the tables that will be displayed on the dashboard
     all_metrics_table = MiniFrame(title=dashboard)
-    avg_metrics_table = MiniFrame(title=dashboard)    
+    avg_metrics_table = MiniFrame(title=dashboard)
 
     if len(experiments) == 0:
         # return empty tables if no experiments are found
@@ -67,7 +69,6 @@ def make_dashboard_table(
         experiment_id=[experiment.experiment_id for experiment in experiments],
         force=[force for _ in experiments],
         skip_on_fail=[skip_on_fail for _ in experiments],
-        quiet=quiet,
     )
 
     # validate that all models have completed all tasks
@@ -131,4 +132,6 @@ def make_dashboard_table(
             average = (sum(filtered_scores) / len(filtered_scores)) if filtered_scores else 0.0
             avg_metrics_table.add(col=group_name, row=model, val=average)
 
-    return DashboardTables(all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model=missing_by_model)
+    return DashboardTables(
+        all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model=missing_by_model
+    )

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -64,11 +64,6 @@ def make_dashboard_table(
         quiet=True,
     )
 
-    import random
-    metrics = [m for m in metrics if not m.alias.startswith("mmlu_jurisprudence")] + random.sample([m for m in metrics if m.alias.startswith("mmlu_jurisprudence")], len([m for m in metrics if m.alias.startswith("mmlu_jurisprudence")]) // 2)
-    # Log the number of metrics
-    logger.info(f"Testing {len(metrics)} metrics after randomly removing half of the mmlu_jurisprudence metrics")
-
     # validate that all models have completed all tasks
     missing_by_model = validate_metrics_coverage(metrics)
 

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -1,41 +1,45 @@
 import logging
 import re
-from typing import NamedTuple
+from dataclasses import dataclass, field
 
 from cookbook.constants import ALL_NAMED_GROUPS
 from cookbook.eval.datalake import FindExperiments, MetricsAll
 from cookbook.eval.miniframe import MiniFrame
 
+
 logger = logging.getLogger(__name__)
 
 
-class DashboardTables(NamedTuple):
-    all_metrics: MiniFrame
-    avg_metrics: MiniFrame
-    missing_by_model: dict[str, list[str]]
+@dataclass
+class DashboardTables:
+    metrics: MiniFrame
+    averages: MiniFrame
+    missing_tasks: dict[str, list[str]] = field(default_factory=dict)
 
+    @classmethod
+    def from_title(cls, title: str) -> "DashboardTables":
+        return cls(metrics=MiniFrame(title=title), averages=MiniFrame(title=title))
 
-def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]:
-    """Validate that all models have completed all tasks and return missing combinations.
+    def find_missing_tasks(self, metrics: list[MetricsAll]):
+        """Validate that all models have completed all tasks and return missing combinations.
 
-    Returns:
-        Dict mapping model names to lists of missing task names.
-    """
-    # Get unique model and task names
-    unique_model_names = {metric.model_name for metric in metrics if metric.model_name is not None}
-    unique_task_names = {metric.alias for metric in metrics if metric.alias is not None}
+        Returns:
+            Dict mapping model names to lists of missing task names.
+        """
+        # Get unique model and task names
+        unique_model_names = {metric.model_name for metric in metrics if metric.model_name is not None}
+        unique_task_names = {metric.alias for metric in metrics if metric.alias is not None}
 
-    # Check for missing task-model combinations
-    missing_by_model: dict[str, list[str]] = {}
-    for model in unique_model_names:
-        missing_tasks: list[str] = []
-        for task in unique_task_names:
-            if not any(m.model_name == model and m.alias == task for m in metrics):
-                missing_tasks.append(task)
-        if missing_tasks:
-            missing_by_model[model] = missing_tasks
+        assert len(self.missing_tasks) == 0, "Missing tasks already found"
 
-    return missing_by_model
+        # Check for missing task-model combinations
+        for model in unique_model_names:
+            missing_tasks: list[str] = []
+            for task in unique_task_names:
+                if not any(m.model_name == model and m.alias == task for m in metrics):
+                    missing_tasks.append(task)
+            if missing_tasks:
+                self.missing_tasks[model] = missing_tasks
 
 
 def make_dashboard_table(
@@ -58,12 +62,11 @@ def make_dashboard_table(
     logger.info(f"Found {len(experiments)} experiments in dashboard {dashboard}")
 
     # these are the tables that will be displayed on the dashboard
-    all_metrics_table = MiniFrame(title=dashboard)
-    avg_metrics_table = MiniFrame(title=dashboard)
+    tables = DashboardTables.from_title(dashboard)
 
     if len(experiments) == 0:
         # return empty tables if no experiments are found
-        return DashboardTables(all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model={})
+        return tables
 
     metrics = MetricsAll.prun(
         experiment_id=[experiment.experiment_id for experiment in experiments],
@@ -72,7 +75,7 @@ def make_dashboard_table(
     )
 
     # validate that all models have completed all tasks
-    missing_by_model = validate_metrics_coverage(metrics)
+    tables.find_missing_tasks(metrics)
 
     for metric in metrics:
         if metric.is_aggregate:
@@ -104,15 +107,15 @@ def make_dashboard_table(
             continue
 
         # add primary score
-        all_metrics_table.add(col=metric.alias, row=metric.model_name, val=metric.metrics.primary_score)
+        tables.metrics.add(col=metric.alias, row=metric.model_name, val=metric.metrics.primary_score)
 
         # add bpb if available and selected
         if metric.metrics.bpb is not None and show_bpb:
-            all_metrics_table.add(col=f"{metric.alias}:bpb", row=metric.model_name, val=metric.metrics.bpb)
+            tables.metrics.add(col=f"{metric.alias}:bpb", row=metric.model_name, val=metric.metrics.bpb)
 
     # remove metrics that do not have any models evaluated against them
     if not show_partial:
-        all_metrics_table = all_metrics_table.drop_empty()
+        tables.metrics = tables.metrics.drop_empty()
 
     for group_name, tasks in ALL_NAMED_GROUPS.items():
         if "mmlu" in group_name and not average_mmlu:
@@ -122,7 +125,7 @@ def make_dashboard_table(
         elif "gen" in group_name and not average_generative:
             continue
 
-        tasks_table = all_metrics_table.keep_cols(*tasks)
+        tasks_table = tables.metrics.keep_cols(*tasks)
         if len(tasks_table) == 0:
             # no need to keep averages for groups that have no models evaluated against their tasks
             continue
@@ -130,8 +133,6 @@ def make_dashboard_table(
         for model, scores in tasks_table.rows:
             filtered_scores = [s for s in scores if s is not None]
             average = (sum(filtered_scores) / len(filtered_scores)) if filtered_scores else 0.0
-            avg_metrics_table.add(col=group_name, row=model, val=average)
+            tables.averages.add(col=group_name, row=model, val=average)
 
-    return DashboardTables(
-        all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model=missing_by_model
-    )
+    return tables

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -20,7 +20,7 @@ def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]
     # Check for missing task-model combinations
     missing_by_model: dict[str, list[str]] = {}
     for model in unique_model_names:
-        missing_tasks = []
+        missing_tasks: list[str] = []
         for task in unique_task_names:
             if not any(m.model_name == model and m.alias == task for m in metrics):
                 missing_tasks.append(task)

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -1,11 +1,17 @@
 import logging
 import re
+from typing import NamedTuple
 
 from cookbook.constants import ALL_NAMED_GROUPS
 from cookbook.eval.datalake import FindExperiments, MetricsAll
 from cookbook.eval.miniframe import MiniFrame
 
 logger = logging.getLogger(__name__)
+
+class DashboardTables(NamedTuple):
+    all_metrics: MiniFrame
+    avg_metrics: MiniFrame
+    missing_by_model: dict[str, list[str]]
 
 def validate_metrics_coverage(metrics: list[MetricsAll]) -> dict[str, list[str]]:
     """Validate that all models have completed all tasks and return missing combinations.
@@ -43,7 +49,7 @@ def make_dashboard_table(
     show_partial: bool = True,
     force: bool = False,
     skip_on_fail: bool = False,
-) -> tuple[MiniFrame, MiniFrame]:
+) -> DashboardTables:
     experiments = FindExperiments.run(dashboard=dashboard)
 
     logger.info(f"Found {len(experiments)} experiments in dashboard {dashboard}")
@@ -54,7 +60,7 @@ def make_dashboard_table(
 
     if len(experiments) == 0:
         # return empty tables if no experiments are found
-        return all_metrics_table, avg_metrics_table
+        return DashboardTables(all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model={})
 
     metrics = MetricsAll.prun(
         experiment_id=[experiment.experiment_id for experiment in experiments],
@@ -124,4 +130,4 @@ def make_dashboard_table(
             average = (sum(filtered_scores) / len(filtered_scores)) if filtered_scores else 0.0
             avg_metrics_table.add(col=group_name, row=model, val=average)
 
-    return all_metrics_table, avg_metrics_table, missing_by_model
+    return DashboardTables(all_metrics=all_metrics_table, avg_metrics=avg_metrics_table, missing_by_model=missing_by_model)

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -49,6 +49,7 @@ def make_dashboard_table(
     show_partial: bool = True,
     force: bool = False,
     skip_on_fail: bool = False,
+    quiet: bool = False,
 ) -> DashboardTables:
     experiments = FindExperiments.run(dashboard=dashboard)
 
@@ -66,7 +67,7 @@ def make_dashboard_table(
         experiment_id=[experiment.experiment_id for experiment in experiments],
         force=[force for _ in experiments],
         skip_on_fail=[skip_on_fail for _ in experiments],
-        quiet=True,
+        quiet=quiet,
     )
 
     # validate that all models have completed all tasks

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -21,10 +21,15 @@ class DashboardTables:
         return cls(metrics=MiniFrame(title=title), averages=MiniFrame(title=title))
 
     def find_missing_tasks(self, metrics: list[MetricsAll]):
-        """Validate that all models have completed all tasks and return missing combinations.
+        """
+        This method looks for missing task-model combinations. A missing task for a model is a task whose
+        result exists only for some models.
 
-        Returns:
-            Dict mapping model names to lists of missing task names.
+        We need to keep track of these missing tasks because they will skew averages in unexpected ways
+        otherwise.
+
+        They are also useful for users to debug issues with Datalake, since they can identify which Beaker
+        runs have not been uploaded correctly.
         """
         # Get unique model and task names
         unique_model_names = {metric.model_name for metric in metrics if metric.model_name is not None}
@@ -38,6 +43,8 @@ class DashboardTables:
             for task in unique_task_names:
                 if not any(m.model_name == model and m.alias == task for m in metrics):
                     missing_tasks.append(task)
+
+            # only append a model if it has 1+ missing task
             if missing_tasks:
                 self.missing_tasks[model] = missing_tasks
 

--- a/src/cookbook/model/builder.py
+++ b/src/cookbook/model/builder.py
@@ -49,7 +49,13 @@ from olmo_core.train.train_module import (
     TransformerActivationCheckpointingMode,
 )
 
-from cookbook.aliases import AnnealConfig, MetricBackend, MetricsConfig, SchedulerType, SourceInstance
+from cookbook.aliases import (
+    AnnealConfig,
+    MetricBackend,
+    MetricsConfig,
+    SchedulerType,
+    SourceInstance,
+)
 from cookbook.cli.core import estimate_batch_size
 from cookbook.data.dataset import MixtureBuilder
 from cookbook.model.config import (


### PR DESCRIPTION
Example test of when there is a subset of runs that is missing a result. the results still display but also shows what models are missing which tasks. 


Below is what it looks like with a test directly in `results.py` after Metrics
```

    import random
    metrics = [m for m in metrics if not m.alias.startswith("mmlu_jurisprudence")] + random.sample([m for m in metrics if m.alias.startswith("mmlu_jurisprudence")], len([m for m in metrics if m.alias.startswith("mmlu_jurisprudence")]) // 2)
    # Log the number of metrics
    logger.info(f"Testing {len(metrics)} metrics after randomly removing half of the mmlu_jurisprudence metrics")
```

which results in:

```
(olmo-cookbook) ➜  olmo-cookbook git:(kyle/missing-metrics-log) ✗ olmo-cookbook-eval results \                                                                                                                                                                                                                    
    --dashboard alldressed_v1/dedup_ablations_v1_BLESSED \
    --tasks mmlu:rc \
    --format json | jq '.'
        😱 Model olmo2-1b-5xC-dedupablate-minhash-suffar200-ec4228ef_step61007-hf is missing tasks:             mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-10shard-f06879b0_step61007-hf is missing tasks:               mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-dclm-4f3f3710_step61007-hf is missing tasks:          mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-bff-3f4bd9ee_step61007-hf is missing tasks:           mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-10shard-subsample23-9898bad9_step61007-hf is missing tasks:           mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-d34e016c_step61007-hf is missing tasks:               mmlu_jurisprudence:rc::olmes


{
  "mmlu:rc": {
    "olmo2-1b-5xC-dedupablate-minhash-suffar500-9adf539e_step61007-hf": 0.32295043669132395,
    "olmo2-1b-5xC-dedupablate-minhash-suffar200-ec4228ef_step61007-hf": 0.3186725502877823,
    "olmo2-1b-5xC-dedupablate-dclm-4f3f3710_step61007-hf": 0.3130879493396065,
    "olmo2-1b-5xC-dedupablate-bff-10x-bdc298e7_step61007-hf": 0.307823330544886,
    "olmo2-1b-5xC-dedupablate-minhash-10shard-subsample23-9898bad9_step61007-hf": 0.3071059617719835,
    "olmo2-1b-5xC-dedupablate-minhash-10shard-f06879b0_step61007-hf": 0.3045658144264798,
    "olmo2-1b-5xC-dedupablate-minhash-dclm-9e4ccbd5_step61007-hf": 0.30260338493987005,
    "olmo2-1b-5xC-dedupablate-minhash-d34e016c_step61007-hf": 0.2997252957279518,
    "olmo2-1b-5xC-dedupablate-control-4a694704_step61007-hf": 0.2990842377563057,
    "olmo2-1b-5xC-dedupablate-bff-3f4bd9ee_step61007-hf": 0.29821941699389326,
    "olmo2-1b-5xC-dedupablate-naive-364c27cb_step61007-hf": 0.29635774027534895
  }
}
```

or
```
(olmo-cookbook) ➜  olmo-cookbook git:(kyle/missing-metrics-log) ✗ olmo-cookbook-eval results \                               
    --dashboard alldressed_v1/dedup_ablations_v1_BLESSED \
    --tasks mmlu:rc  
        😱 Model olmo2-1b-5xC-dedupablate-control-4a694704_step61007-hf is missing tasks:               mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-bff-10x-bdc298e7_step61007-hf is missing tasks:               mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-naive-364c27cb_step61007-hf is missing tasks:         mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-dclm-9e4ccbd5_step61007-hf is missing tasks:          mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-d34e016c_step61007-hf is missing tasks:               mmlu_jurisprudence:rc::olmes
        😱 Model olmo2-1b-5xC-dedupablate-minhash-10shard-subsample23-9898bad9_step61007-hf is missing tasks:           mmlu_jurisprudence:rc::olmes


                        alldressed_v1/dedup_ablations_v1_BLESSED                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃                                                                            ┃ mmlu:rc ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ olmo2-1b-5xC-dedupablate-minhash-suffar500-9adf539e_step61007-hf           │  32.30  │
│ olmo2-1b-5xC-dedupablate-minhash-suffar200-ec4228ef_step61007-hf           │  31.84  │
│ olmo2-1b-5xC-dedupablate-dclm-4f3f3710_step61007-hf                        │  31.34  │
│ olmo2-1b-5xC-dedupablate-bff-10x-bdc298e7_step61007-hf                     │  30.82  │
│ olmo2-1b-5xC-dedupablate-minhash-10shard-subsample23-9898bad9_step61007-hf │  30.71  │
│ olmo2-1b-5xC-dedupablate-minhash-10shard-f06879b0_step61007-hf             │  30.54  │
│ olmo2-1b-5xC-dedupablate-minhash-dclm-9e4ccbd5_step61007-hf                │  30.22  │
│ olmo2-1b-5xC-dedupablate-minhash-d34e016c_step61007-hf                     │  29.97  │
│ olmo2-1b-5xC-dedupablate-control-4a694704_step61007-hf                     │  29.90  │
│ olmo2-1b-5xC-dedupablate-bff-3f4bd9ee_step61007-hf                         │  29.82  │
│ olmo2-1b-5xC-dedupablate-naive-364c27cb_step61007-hf                       │  29.65  │
└────────────────────────────────────────────────────────────────────────────┴─────────┘
```


if remove this test, results look fine
```
olmo-cookbook-eval results \
    --dashboard alldressed_v1/dedup_ablations_v1_BLESSED \
    --tasks mmlu:rc
                        alldressed_v1/dedup_ablations_v1_BLESSED                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃                                                                            ┃ mmlu:rc ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ olmo2-1b-5xC-dedupablate-minhash-suffar500-9adf539e_step61007-hf           │  32.30  │
│ olmo2-1b-5xC-dedupablate-minhash-suffar200-ec4228ef_step61007-hf           │  31.84  │
│ olmo2-1b-5xC-dedupablate-dclm-4f3f3710_step61007-hf                        │  31.34  │
│ olmo2-1b-5xC-dedupablate-bff-10x-bdc298e7_step61007-hf                     │  30.78  │
│ olmo2-1b-5xC-dedupablate-minhash-10shard-subsample23-9898bad9_step61007-hf │  30.76  │
│ olmo2-1b-5xC-dedupablate-minhash-10shard-f06879b0_step61007-hf             │  30.54  │
│ olmo2-1b-5xC-dedupablate-minhash-dclm-9e4ccbd5_step61007-hf                │  30.26  │
│ olmo2-1b-5xC-dedupablate-minhash-d34e016c_step61007-hf                     │  30.03  │
│ olmo2-1b-5xC-dedupablate-control-4a694704_step61007-hf                     │  29.91  │
│ olmo2-1b-5xC-dedupablate-bff-3f4bd9ee_step61007-hf                         │  29.82  │
│ olmo2-1b-5xC-dedupablate-naive-364c27cb_step61007-hf                       │  29.64  │
└────────────────────────────────────────────────────────────────────────────┴─────────┘
```