### PR TITLE
Escape whitespace in task name

### DIFF
--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -187,7 +187,7 @@ def evaluate_checkpoint(
 
             # add all tasks in the partition as flag
             partition_tasks = tasks_names[i : i + partition_size] if partition_size else tasks_names
-            escaped_partition_tasks = [json.dumps(task) if task[0] == "{" else task for task in partition_tasks]
+            escaped_partition_tasks = [json.dumps(task) if task[0] == "{" else task.replace(' ', '\\ ') for task in partition_tasks]
 
             local_flags.append(f"--task {' '.join(escaped_partition_tasks)}")
 


### PR DESCRIPTION
Prev: args submitted to oe-eval contains
```
'--task mmlu_pro_biology:mc::none mmlu_pro_business:mc::none mmlu_pro_chemistry:mc::none mmlu_pro_computer science:mc::none ...
```
which "computer science" would be treated as two separate args

After: args become
```
'--task mmlu_pro_biology:mc::none mmlu_pro_business:mc::none mmlu_pro_chemistry:mc::none mmlu_pro_computer\\ science:mc::none ...
```