### PR TITLE
Add --beaker-retries

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -232,6 +232,7 @@ def convert_checkpoint(
     help="Model backend (hf for Hugging Face, vllm for vLLM)",
 )
 @click.option("-g", "--use-gantry", is_flag=True, help="Submit jobs with gantry directly.")
+@click.option("--beaker-retries", type=int, default=0, help="Number of retries for failed evals")
 @click.option(
     "--oe-eval-commit",
     type=str,
@@ -319,6 +320,7 @@ def evaluate_model(
     batch_size: int,
     dry_run: bool,
     beaker_image: str,
+    beaker_retries: int,
     use_gantry: bool,
     gantry_args: str,
     force_venv: bool,
@@ -371,6 +373,7 @@ def evaluate_model(
         batch_size=batch_size,
         dry_run=dry_run,
         beaker_image=beaker_image,
+        beaker_retries=beaker_retries,
         use_gantry=use_gantry,
         gantry_args=gantry_args,
         python_venv_force=force_venv,

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -44,6 +44,7 @@ def evaluate_checkpoint(
     batch_size: int,
     dry_run: bool,
     beaker_image: str,
+    beaker_retries: int,
     use_gantry: bool,
     gantry_args: str | dict,
     python_venv_name: str,
@@ -73,6 +74,11 @@ def evaluate_checkpoint(
 
     # clusters_to_exclude
     clusters_to_exclude: set[str] = set()
+
+    # processing gantry args
+    if isinstance(gantry_args, str):
+        # load gantry args using json
+        gantry_args = json.loads(gantry_args.strip() or "{}")
 
     # Need to figure out how checkpoint is stored!
     if (scheme := urlparse(checkpoint_path).scheme) == "s3":
@@ -116,7 +122,7 @@ def evaluate_checkpoint(
                 env=env,  # pyright: ignore
             )
             flags.append(f"--gantry-secret-hf-read-only '{hf_token_secret}'")
-            flags.append("--gantry-args '{\"hf_token\":true}'")
+            gantry_args = {"hf_token": "true", **gantry_args}
         else:
             print("\n\nWARNING: Hugging Face token not provided; this may cause issues with model download.\n\n")
 
@@ -239,10 +245,8 @@ def evaluate_checkpoint(
             if use_gantry:
                 local_flags.append("--use-gantry")
 
-            # processing gantry args
-            if isinstance(gantry_args, str):
-                # load gantry args using json
-                gantry_args = json.loads(gantry_args.strip() or "{}")
+            if beaker_retries > 0:
+                local_flags.append(f"--beaker-retries {beaker_retries}")
 
             assert isinstance(gantry_args, dict), "gantry_args must be a dictionary"
 


### PR DESCRIPTION
Adds `--beaker-retries` command to run evals multiple times on failures (helps with vLLM flakiness on some models)

Also fixes `gantry_args` -- If you specify gantry args and use vLLM, it adds the argument _twice_, then the oe-eval job fails.