### PR TITLE
allow specifying an oe-eval branch

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -234,6 +234,12 @@ def convert_checkpoint(
 @click.option("-g", "--use-gantry", is_flag=True, help="Submit jobs with gantry directly.")
 @click.option("--beaker-retries", type=int, default=0, help="Number of retries for failed evals")
 @click.option(
+    "--oe-eval-branch",
+    type=str,
+    default=None,
+    help="Branch of the oe-eval toolkit to use; if not provided, use main",
+)
+@click.option(
     "--oe-eval-commit",
     type=str,
     default=None,
@@ -300,6 +306,7 @@ def convert_checkpoint(
     help="Suffix to add to the run name",
 )
 def evaluate_model(
+    oe_eval_branch: str,
     oe_eval_commit: str,
     checkpoint_path: str,
     aws_access_key_id: str,
@@ -353,6 +360,7 @@ def evaluate_model(
     tasks = [e for t in tasks for e in (ALL_EVAL_TASKS.get(t.lstrip("*"), [t]) if t.startswith("*") else [t])]
     
     evaluate_checkpoint(
+        oe_eval_branch=oe_eval_branch,
         oe_eval_commit=oe_eval_commit,
         checkpoint_path=checkpoint_path,
         aws_access_key_id=aws_access_key_id,

--- a/src/cookbook/cli/utils.py
+++ b/src/cookbook/cli/utils.py
@@ -384,19 +384,14 @@ def clone_repository(git_url: str, commit_hash: Optional[str] = None, branch_nam
         # Execute clone
         subprocess.run(cmd, check=True)
 
-        if commit_hash or branch_name:
-            # Change directory to the cloned repo
-            os.chdir(tmp_dir)
-            
-            if commit_hash and branch_name:
-                subprocess.run(shlex.split(f"git fetch origin {commit_hash}:refs/remotes/origin/{branch_name}"), check=True)
-                subprocess.run(shlex.split(f"git checkout -b temp-checkout {commit_hash}"), check=True)
-            elif commit_hash:
-                subprocess.run(shlex.split(f"git fetch origin '{commit_hash}'"), check=True)
-                subprocess.run(shlex.split(f"git checkout '{commit_hash}'"), check=True)
-            elif branch_name:
-                subprocess.run(shlex.split(f"git fetch origin {branch_name}:refs/remotes/origin/{branch_name}"), check=True)
-                subprocess.run(shlex.split(f"git checkout -b {branch_name} origin/{branch_name}"), check=True)
+        if commit_hash:
+            os.chdir(tmp_dir) # Change directory to the cloned repo
+            subprocess.run(shlex.split(f"git fetch origin '{commit_hash}'"), check=True)
+            subprocess.run(shlex.split(f"git checkout '{commit_hash}'"), check=True)
+        elif branch_name:
+            os.chdir(tmp_dir) # Change directory to the cloned repo
+            subprocess.run(shlex.split(f"git fetch origin {branch_name}:refs/remotes/origin/{branch_name}"), check=True)
+            subprocess.run(shlex.split(f"git checkout -b {branch_name} origin/{branch_name}"), check=True)
 
         return tmp_dir
 

--- a/src/cookbook/cli/utils.py
+++ b/src/cookbook/cli/utils.py
@@ -385,11 +385,13 @@ def clone_repository(git_url: str, commit_hash: Optional[str] = None, branch_nam
         subprocess.run(cmd, check=True)
 
         if commit_hash:
-            os.chdir(tmp_dir) # Change directory to the cloned repo
+            # Change directory to the cloned repo
+            os.chdir(tmp_dir)
             subprocess.run(shlex.split(f"git fetch origin '{commit_hash}'"), check=True)
             subprocess.run(shlex.split(f"git checkout '{commit_hash}'"), check=True)
         elif branch_name:
-            os.chdir(tmp_dir) # Change directory to the cloned repo
+            # Change directory to the cloned repo
+            os.chdir(tmp_dir)
             subprocess.run(shlex.split(f"git fetch origin {branch_name}:refs/remotes/origin/{branch_name}"), check=True)
             subprocess.run(shlex.split(f"git checkout -b {branch_name} origin/{branch_name}"), check=True)
 

--- a/src/cookbook/cli/utils.py
+++ b/src/cookbook/cli/utils.py
@@ -173,7 +173,7 @@ def install_beaker_py(
 
 def install_oe_eval(
     commit_hash: Optional[str],
-    branch_name: Optional[str],
+    commit_branch: Optional[str],
     env: Optional[PythonEnv] = None,
     no_dependencies: bool = True,
     is_editable: bool = False,
@@ -183,7 +183,7 @@ def install_oe_eval(
     print("Installing beaker and gantry clients...")
     install_beaker_py(env)
 
-    oe_eval_dir = clone_repository(OE_EVAL_GIT_URL, commit_hash, branch_name)
+    oe_eval_dir = clone_repository(OE_EVAL_GIT_URL, commit_hash, commit_branch)
 
     print(f"Installing OE-Eval from {oe_eval_dir}" + (" in editable mode" if is_editable else "") + "...")
     cmd = [
@@ -363,7 +363,7 @@ def make_eval_run_name(checkpoint_path: str, add_bos_token: bool, name_suffix: s
     )
 
 
-def clone_repository(git_url: str, commit_hash: Optional[str] = None, branch_name: Optional[str] = None) -> str:
+def clone_repository(git_url: str, commit_hash: Optional[str] = None, commit_branch: Optional[str] = None) -> str:
     # current directory
     current_dir = os.getcwd()
 
@@ -384,16 +384,17 @@ def clone_repository(git_url: str, commit_hash: Optional[str] = None, branch_nam
         # Execute clone
         subprocess.run(cmd, check=True)
 
+        if commit_branch:
+            # Change directory to the cloned repo
+            os.chdir(tmp_dir)
+            subprocess.run(shlex.split(f"git fetch origin {commit_branch}:refs/remotes/origin/{commit_branch}"), check=True)
+            subprocess.run(shlex.split(f"git checkout -b {commit_branch} origin/{commit_branch}"), check=True)
+
         if commit_hash:
             # Change directory to the cloned repo
             os.chdir(tmp_dir)
             subprocess.run(shlex.split(f"git fetch origin '{commit_hash}'"), check=True)
             subprocess.run(shlex.split(f"git checkout '{commit_hash}'"), check=True)
-        elif branch_name:
-            # Change directory to the cloned repo
-            os.chdir(tmp_dir)
-            subprocess.run(shlex.split(f"git fetch origin {branch_name}:refs/remotes/origin/{branch_name}"), check=True)
-            subprocess.run(shlex.split(f"git checkout -b {branch_name} origin/{branch_name}"), check=True)
 
         return tmp_dir
 

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -67,7 +67,7 @@ def evaluate_checkpoint(
     oe_eval_dir = install_oe_eval(
         env=env,
         commit_hash=oe_eval_commit,
-        branch_name=oe_eval_branch,
+        commit_branch=oe_eval_branch,
         is_editable=use_gantry,
     )
 

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -25,6 +25,7 @@ from cookbook.constants import (
 
 def evaluate_checkpoint(
     oe_eval_commit: str,
+    oe_eval_branch: str,
     checkpoint_path: str,
     aws_access_key_id: str,
     aws_secret_access_key: str,
@@ -66,6 +67,7 @@ def evaluate_checkpoint(
     oe_eval_dir = install_oe_eval(
         env=env,
         commit_hash=oe_eval_commit,
+        branch_name=oe_eval_branch,
         is_editable=use_gantry,
     )
 


### PR DESCRIPTION
Currently, we can set `--oe-eval-commit` for a commit _on the main branch of oe-eval_. This allows changing the branch. (commit logic is unchanged -- one could point to a commit on a different branch)

```sh
olmo-cookbook-eval evaluate {model} \
    ...
    --oe-eval-branch cookbook-updates \
```


Example command:

```sh
olmo-cookbook-eval evaluate allenai/OLMo-2-0425-1B \
    --tasks arc_easy:rc::olmes:full \
    --priority high \
    --cluster aus80g \
    --num-gpus 1 \
    --model-backend vllm \
    --partition-size 8 \
    --huggingface-secret davidh_HUGGING_FACE_HUB_TOKEN \
    --vllm-use-v1-spec \
    --dashboard cookbook-debug \
    --workspace ai2/olmo-3-evals \
    --model-args max_length=4096,trust_remote_code=true \
    --use-gantry \
    --oe-eval-branch cookbook-updates
```