### PR TITLE
Specify Model Revisions for oe-eval

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -276,6 +276,12 @@ def convert_checkpoint(
     help="Extra arguments to pass to the model",
 )
 @click.option(
+    "--revision",
+    type=str,
+    default=None,
+    help="Revision of model in HF hub",
+)
+@click.option(
     "--fim-tokens",
     type=click.Choice(list(FIM_TOKENS.keys())),
     default=None,
@@ -308,6 +314,7 @@ def evaluate_model(
     cluster: str,
     huggingface_secret: str,
     add_bos_token: bool,
+    revision: str,
     budget: str,
     priority: str,
     num_gpus: int,
@@ -361,6 +368,7 @@ def evaluate_model(
         cluster=cluster,
         huggingface_secret=huggingface_secret,
         add_bos_token=add_bos_token,
+        revision=revision,
         budget=budget,
         priority=priority,
         num_gpus=num_gpus,

--- a/src/cookbook/eval/datalake.py
+++ b/src/cookbook/eval/datalake.py
@@ -169,16 +169,7 @@ class FindExperiments(BaseDatalakeItem):
         # Sort records by created date (newest first)
         all_records.sort(key=lambda x: x.created, reverse=True)
 
-        # Filter to keep only the newest experiment for each (model_name, task_name) pair
-        unique_records = {}
-        for record in all_records:
-            key = (record.model_name, record.task_name)
-            if key not in unique_records:
-                unique_records[key] = record
-
-        records = list(unique_records.values())
-
-        return records
+        return all_records
 
 
 @dataclass
@@ -247,7 +238,11 @@ class MetricsAll(BaseDatalakeItem):
 
     @property
     def model_name(self) -> str | None:
-        return self.model_config.get("model", None)
+        model_name = self.model_config.get("model", None)
+        if 'revision' in self.model_config and \
+            self.model_config['revision'] is not None:
+            model_name = model_name + ':' + self.model_config['revision']
+        return model_name
 
     @property
     def is_aggregate(self) -> bool:

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -32,6 +32,7 @@ def evaluate_checkpoint(
     cluster: str,
     huggingface_secret: str,
     add_bos_token: bool,
+    revision: str,
     budget: str,
     priority: str,
     num_gpus: int,
@@ -240,6 +241,10 @@ def evaluate_checkpoint(
             # set beaker image
             if beaker_image:
                 local_flags.append(f"--beaker-image {beaker_image}")
+
+            # set revision
+            if revision:
+                local_flags.append(f"--revision {revision}")
 
             # set gantry
             if use_gantry:

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 import re
 from typing import NamedTuple
@@ -64,6 +65,19 @@ def make_dashboard_table(
     # keep track of bpb metrics names; we need these to warn users if a metric is missing,
     # but we wanna report the original metric name in the warning.
     bpb_to_og_metric_name_map: dict[str, str] = {}
+    
+    # Filter to keep only the newest metric for each (model_name, alias) pair
+    unique_metrics = {}
+    for metric in metrics:
+        key = (metric.model_name, metric.alias)
+        if key in unique_metrics:
+            metric_dt = datetime.fromisoformat(metric.current_date.replace(" UTC", "+00:00"))
+            existing_dt = datetime.fromisoformat(unique_metrics[key].current_date.replace(" UTC", "+00:00"))
+            if metric_dt > existing_dt:
+                unique_metrics[key] = metric
+        else:
+            unique_metrics[key] = metric
+    metrics = list(unique_metrics.values())
 
     for metric in metrics:
         if metric.is_aggregate:


### PR DESCRIPTION
Allows passing the `--revision` argument to oe-eval-internal.

For example:

```sh
olmo-cookbook-eval evaluate \
    allenai/OLMo-2-1124-7B \
    ...
    --revision stage1-step240000-tokens1007B
```