### PR TITLE
Adding support for overriding number of shots in oe-eval.

### DIFF
--- a/src/cookbook/cli/utils.py
+++ b/src/cookbook/cli/utils.py
@@ -91,7 +91,7 @@ def get_huggingface_token() -> Optional[str]:
         return os.getenv("HUGGINGFACE_TOKEN")
 
     try:
-        from huggingface_hub.constants import HF_TOKEN_PATH
+        from huggingface_hub.constants import HF_TOKEN_PATH  # pyright: ignore
 
         with open(HF_TOKEN_PATH, "r") as f:
             return f.read().strip()
@@ -345,7 +345,12 @@ def add_aws_flags(
     return True
 
 
-def make_eval_run_name(checkpoint_path: str, add_bos_token: bool, name_suffix: str | None = None) -> str:
+def make_eval_run_name(
+    checkpoint_path: str,
+    add_bos_token: bool,
+    num_shots: int | None = None,
+    name_suffix: str | None = None,
+) -> str:
     path_no_scheme = (p := urlparse(checkpoint_path)).netloc + p.path
 
     step_suffix = None
@@ -358,6 +363,7 @@ def make_eval_run_name(checkpoint_path: str, add_bos_token: bool, name_suffix: s
         os.path.basename(path_no_scheme)
         + (f"_{step_suffix}" if step_suffix else "")
         + ("_bos" if add_bos_token else "")
+        + (f"_s{num_shots}" if num_shots is not None else "")
         + (f"_{name_suffix}" if name_suffix else "")
     )
 


### PR DESCRIPTION
This PR adds a new option to the eval command: `--num-shots`. The option overrides the number of shots specified in the task definition in oe-eval. Similarly to `--add-bos-token`, this option will result in a new run name (otherwise we risk overriding existing runs).