### PR TITLE
Add v0 midtraining config

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -278,8 +278,9 @@ def convert_checkpoint(
 @click.option(
     "--task-args",
     type=str,
-    default="",
-    help="Extra arguments to pass to the task config",
+    default=[],
+    multiple=True,
+    help="Extra arguments to pass to the task config. Can specify multiple args.",
 )
 @click.option(
     "--model-args",
@@ -355,7 +356,7 @@ def evaluate_model(
     vllm_for_mc: bool,
     compute_gold_bpb: bool,
     model_args: str,
-    task_args: str,
+    task_args: list[str],
     fim_tokens: str,
     vllm_use_v1_spec: bool,
     use_backend_in_run_name: bool,
@@ -371,7 +372,7 @@ def evaluate_model(
     extra_args = re.sub(r"\\-", "-", extra_args.strip())
 
     parsed_task_args: dict[str, str] = {}
-    for arg in task_args.split(",,"):
+    for arg in task_args:
         if not (arg := arg.strip()):
             continue
         key, value = arg.split("=")

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -276,6 +276,12 @@ def convert_checkpoint(
     help="Whether to compute gold BPB when evaluating generative tasks.",
 )
 @click.option(
+    "--task-args",
+    type=str,
+    default="",
+    help="Extra arguments to pass to the task config",
+)
+@click.option(
     "--model-args",
     type=str,
     default="",
@@ -349,6 +355,7 @@ def evaluate_model(
     vllm_for_mc: bool,
     compute_gold_bpb: bool,
     model_args: str,
+    task_args: str,
     fim_tokens: str,
     vllm_use_v1_spec: bool,
     use_backend_in_run_name: bool,
@@ -362,6 +369,13 @@ def evaluate_model(
 
     # Remove any escaped hyphens in extra_args
     extra_args = re.sub(r"\\-", "-", extra_args.strip())
+
+    parsed_task_args: dict[str, str] = {}
+    for arg in task_args.split(",,"):
+        if not (arg := arg.strip()):
+            continue
+        key, value = arg.split("=")
+        parsed_task_args[key] = json.loads(value)
 
     parsed_model_args: dict[str, str] = {}
     for arg in model_args.split(","):
@@ -408,6 +422,7 @@ def evaluate_model(
         vllm_memory_utilization=vllm_memory_utilization,
         vllm_for_mc=vllm_for_mc,
         compute_gold_bpb=compute_gold_bpb,
+        task_args=parsed_task_args,
         model_args=parsed_model_args,
         fim_tokens=fim_tokens,
         use_vllm_v1_spec=vllm_use_v1_spec,

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -206,6 +206,11 @@ class MMLUMCGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{category}:mc::olmes" for category in constants.MMLU_CATEGORIES]
 
 
+@NamedTasksGroupRegistry.register("mmlu:cot::hamish_zs_reasoning")
+class MMLUHamishZSReasoningGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"{category}:cot::hamish_zs_reasoning" for category in constants.MMLU_CATEGORIES]
+
+
 @NamedTasksGroupRegistry.register("core:rc")
 class CoreRCGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{task}:rc::olmes" for task in constants.ALL_CORE_TASKS]
@@ -298,6 +303,11 @@ class MinervaGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{subtask}::olmes" for subtask in constants.ALL_MINERVA_TASKS]
 
 
+@NamedTasksGroupRegistry.register("minerva::hamish_zs_reasoning")
+class MinervaHamishZSReasoningGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"{subtask}::hamish_zs_reasoning" for subtask in constants.ALL_MINERVA_TASKS]
+
+
 @NamedTasksGroupRegistry.register("math")
 class MathGroup(BaseAverageNamedTasksGroup):
     tasks = [
@@ -320,6 +330,11 @@ class CodeGroup(BaseAverageNamedTasksGroup):
 @NamedTasksGroupRegistry.register("agi_eval")
 class AgiEvalGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{task}:1shot::olmes" for task in constants.AGI_EVAL_ENGLISH_TASKS]
+
+
+@NamedTasksGroupRegistry.register("agi_eval_english:0shot_cot::hamish_zs_reasoning")
+class AgiEvalEnglishHamishZsReasoningGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"{task}:0shot_cot::hamish_zs_reasoning" for task in constants.AGI_EVAL_ENGLISH_TASKS]
 
 
 @NamedTasksGroupRegistry.register("starcoder")
@@ -366,6 +381,11 @@ class MtMbppGroup(BaseAverageNamedTasksGroup):
 @NamedTasksGroupRegistry.register("mt_mbpp_v2fix")
 class MtMbppV2fixGroup(BaseAverageNamedTasksGroup):
     tasks = [task for task in constants.MULTILINGUAL_MBPP_TASKS_V2]
+
+
+@NamedTasksGroupRegistry.register("bbh:cot::hamish_zs_reasoning")
+class BBHHamishZSReasoningGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"bbh_{category}:cot::hamish_zs_reasoning" for category in constants.BBH_TASKS]
 
 
 def make_helmet_group(helmet_length: int) -> Type[BaseAverageNamedTasksGroup]:
@@ -648,4 +668,26 @@ class Olmo3Dev7bMainGroup(BaseAverageOfAveragesNamedTasksGroup):
         BasicRCGroup(),
         GenXlargeGroup(),
         CruxEvalGroup(),
+    ]
+
+
+@NamedTasksGroupRegistry.register("olmo3:dev:midtrain:v0")
+class Olmo3Dev7bMainGroup(BaseAverageOfAveragesNamedTasksGroup):
+    tasks = [
+        "aime::hamish_zs_reasoning",
+        "alpaca_eval_v3::hamish_zs_reasoning",
+        "codex_humanevalplus:0-shot-chat::tulu-thinker",
+        "gpqa:0shot_cot::hamish_zs_reasoning", # requires 4096 context window
+        "gsm8k::zs_cot_latex",  #### to replace "gsm8k::hamish_zs_reasoning"
+        "ifeval::hamish_zs_reasoning",
+        "mbppplus:0-shot-chat::tulu-thinker",
+        "minerva_math_500::hamish_zs_reasoning",
+        "popqa::hamish_zs_reasoning",  #### todo: fix and test this guy.
+        AgiEvalEnglishHamishZsReasoningGroup(),
+        BBHHamishZSReasoningGroup(),
+        MinervaHamishZSReasoningGroup(),
+        MMLUHamishZSReasoningGroup(),
+
+        # https://beaker.allen.ai/orgs/ai2/workspaces/olmo-3-evals/work/01JYPHTGX1E1HJQTV7S9A52E7M/logs?jobId=01JYPHTH5SGKET46T3SWJVT92C
+        # "zebralogic::hamish_zs_reasoning", # broken: metric error
     ]

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -679,16 +679,29 @@ class Olmo3Dev7bMainGroup(BaseAverageOfAveragesNamedTasksGroup):
         "alpaca_eval_v3::hamish_zs_reasoning",
         "codex_humanevalplus:0-shot-chat::tulu-thinker",
         "gpqa:0shot_cot::hamish_zs_reasoning", # requires 4096 context window
-        "gsm8k::zs_cot_latex",  #### to replace "gsm8k::hamish_zs_reasoning"
+        "gsm8k::zs_cot_latex",  #### from adapt: to replace "gsm8k::hamish_zs_reasoning"
         "ifeval::hamish_zs_reasoning",
         "mbppplus:0-shot-chat::tulu-thinker",
         "minerva_math_500::hamish_zs_reasoning",
-        "popqa::hamish_zs_reasoning",  #### todo: fix and test this guy.
+        "popqa::hamish_zs_reasoning",  #### from adapt: fix and test this guy.
         AgiEvalEnglishHamishZsReasoningGroup(),
         BBHHamishZSReasoningGroup(),
         MinervaHamishZSReasoningGroup(),
         MMLUHamishZSReasoningGroup(),
+        "zebralogic::hamish_zs_reasoning"
+        "livecodebench_codegeneration::tulu-thinker",
 
-        # https://beaker.allen.ai/orgs/ai2/workspaces/olmo-3-evals/work/01JYPHTGX1E1HJQTV7S9A52E7M/logs?jobId=01JYPHTH5SGKET46T3SWJVT92C
-        # "zebralogic::hamish_zs_reasoning", # broken: metric error
+        ### Not yet implemented
+        # cruxeval
+        # simpleqa
+        # gpqa diamond
+        # AMC 22/23
+        # math OOD
+        # turnwise
+        # typos eval
+        # bcfl v3
+        # ace bench
+        # appworld
+
+        # all safety
     ]

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -334,7 +334,7 @@ class AgiEvalGroup(BaseAverageNamedTasksGroup):
 
 @NamedTasksGroupRegistry.register("agi_eval_english:0shot_cot::hamish_zs_reasoning")
 class AgiEvalEnglishHamishZsReasoningGroup(BaseAverageNamedTasksGroup):
-    tasks = [f"{task}:0shot_cot::hamish_zs_reasoning" for task in constants.AGI_EVAL_ENGLISH_TASKS]
+    tasks = [f"agi_eval_{task}:0shot_cot::hamish_zs_reasoning" for task in constants.AGI_EVAL_ENGLISH_TASKS]
 
 
 @NamedTasksGroupRegistry.register("starcoder")
@@ -674,6 +674,7 @@ class Olmo3Dev7bMainGroup(BaseAverageOfAveragesNamedTasksGroup):
 @NamedTasksGroupRegistry.register("olmo3:dev:midtrain:v0")
 class Olmo3Dev7bMainGroup(BaseAverageOfAveragesNamedTasksGroup):
     tasks = [
+        # Everything in this task set is 0-shot
         "aime::hamish_zs_reasoning",
         "alpaca_eval_v3::hamish_zs_reasoning",
         "codex_humanevalplus:0-shot-chat::tulu-thinker",


### PR DESCRIPTION
Adds relevant named groups based on https://docs.google.com/document/d/1fjz0HYraFlA6QXdNp7a7ofLQTBMPNluminHmtjOQIiU/edit?tab=t.0

Also adds the ability to pass `--task-args`

**Basic launch command**

```sh
olmo-cookbook-eval evaluate allenai/OLMo-2-1124-7B -t olmo3:dev:midtrain:v0 -d midtraining-test

olmo-cookbook-eval results -t olmo3:dev:midtrain:v0 -d midtraining-test
```

**Full launch command**

```sh
olmo-cookbook-eval evaluate allenai/OLMo-2-1124-7B \
    --tasks olmo3:dev:midtrain:v0 \
    --priority high \
    --cluster aus80g \
    --num-gpus 1 \
    --huggingface-secret davidh_HUGGING_FACE_HUB_TOKEN \
    --vllm-use-v1-spec \
    --partition-size 1 \
    --dashboard midtraining-test-basic-template-stop-toks \
    --workspace ai2/olmo-3-evals \
    --no-compute-gold-bpb \
    --model-args chat_template=basic_answer \
    --use-gantry \
    --gantry-args env-secret="OPENAI_API_KEY=openai_api_key" \
    --oe-eval-branch davidh/basic-tokenizer \
    --task-args chat_overrides="{\"generation_kwargs\": {\"stop_sequences\": [\"Problem:\", \"Answer:\", \"Question:\", \"</s>\", \"<|eot_id|>\"]}}"
```

**Example results**

```sh
olmo-cookbook-eval results -t olmo3:dev:midtrain:v0 -d midtraining-test-basic-template-stop-toks
```

```
                                                                                                                                                                     midtraining-test-basic-template-stop-toks
┏━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┓
┃                          ┃ mbppplus:0-shot-chat::t… ┃ minerva_math_500::hamis… ┃ codex_humanevalplus:0-s… ┃ ifeval::hamish_zs_reaso… ┃ gsm8k::zs_cot_latex ┃ aime::hamish_zs_reasoni… ┃ alpaca_eval_v3::hamish_… ┃ popqa::hamish_zs_reason… ┃ mmlu:cot::hamish_zs_rea… ┃ minerva::hamish_zs_reas… ┃ bbh:cot::hamish_zs_reaso… ┃ agi_eval_english:0shot_… ┃ olmo3:dev:midtrain:v0 ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━┩
│ OLMo-2-1124-7B           │           4.63           │           0.00           │           0.24           │          25.69           │        45.56        │           0.00           │          102.01          │            -             │            -             │            -             │             -             │          36.46           │           -           │
│ OLMo-7B-0724-hf          │           1.11           │           0.00           │           0.06           │          18.11           │        5.08         │           0.00           │          100.07          │          22.32           │          35.82           │           0.00           │           21.93           │          32.82           │         18.34         │
│ olmo2-7b_10b-anneal_web… │           1.01           │           0.00           │           3.72           │          18.67           │        1.90         │           0.00           │          45.56           │            -             │          52.19           │           0.00           │           22.48           │          28.09           │           -           │
└──────────────────────────┴──────────────────────────┴──────────────────────────┴──────────────────────────┴──────────────────────────┴─────────────────────┴──────────────────────────┴──────────────────────────┴──────────────────────────┴──────────────────────────┴──────────────────────────┴───────────────────────────┴──────────────────────────┴───────────────────────┘
```

**Notes:**

- Not all the configs from the document exist in oe-eval. I chatted with @fabrahman to get the updated configs.