### PR TITLE
Improve APIs for Datalake add/remove from dashboard, cleanup code for managing results.

### DIFF
--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -1,13 +1,11 @@
 import json
 import logging
 import re
-import sys
 from typing import Optional
 
 import click
 from rich.console import Console
 from rich.table import Table
-from rich.pretty import pprint
 
 from cookbook.cli.utils import (
     get_aws_access_key_id,
@@ -26,11 +24,16 @@ from cookbook.constants import (
     TRANSFORMERS_COMMIT_HASH,
     TRANSFORMERS_GIT_URL,
 )
-from cookbook.eval.named_tasks import BaseNamedTasksGroup, NamedTasksGroupRegistry
+from cookbook.eval.named_tasks import NamedTasksGroupRegistry
 from cookbook.eval.conversion import run_checkpoint_conversion
 from cookbook.eval.datalake import AddToDashboard, FindExperiments, RemoveFromDashboard
 from cookbook.eval.evaluation import evaluate_checkpoint
-from cookbook.eval.results import make_dashboard_table, print_missing_tasks
+from cookbook.eval.results import (
+    make_dashboard_table,
+    print_missing_tasks,
+    find_missing_tasks,
+    make_results_from_dashboard
+)
 
 logger = logging.getLogger(__name__)
 
@@ -423,18 +426,11 @@ def evaluate_model(
             name_suffix=name_suffix.strip(),
         )
 
-        # Call the dashboard to get all the missing results
-        missing_tasks = get_results(
-            dashboard,
-            model_name,
-            tasks,
-            format='return_missing',
-            sort_by='avg',
-            sort_column_name=None,
-            sort_descending=None,
-            force=False,
-            skip_on_fail=True,
-        )
+        # to find what to backfill with, we get all results for this dashboard, then filter them
+        # to match this model name, and finally find all missing tasks in results.
+        dashboard_table = make_dashboard_table(dashboard=dashboard)
+        results = make_results_from_dashboard(dashboard_table=dashboard_table, tasks=tasks, models=[model_name])
+        missing_tasks = find_missing_tasks(results=results)
 
         # Override our tasks with the missing set
         if model_name in missing_tasks:
@@ -545,88 +541,25 @@ def get_results(
     force: bool,
     skip_on_fail: bool,
 ) -> None:
-
-    # compile tasks names into regex patterns (if possible)
-    compiled_tasks = [re.compile(task) if re.escape(task) != task else task for task in tasks]
-
-    # we partition between single tasks and named groups; we also keep a set of all tasks names,
-    # which we will use later to print any missing tasks.
-    named_groups: list[BaseNamedTasksGroup] = []
-    columns_filter_tasks: list[str | re.Pattern] = compiled_tasks[:]
-    for compiled_task in compiled_tasks:
-        matching_groups = [NamedTasksGroupRegistry.get(ng) for ng in NamedTasksGroupRegistry.search(compiled_task)]
-        named_groups.extend(matching_groups)
-        columns_filter_tasks.extend(t for ng in matching_groups for t in ng.expanded_tasks)
-
     # we get the metrics table from the datalake
-    metrics_table = make_dashboard_table(
+    dashboard_table = make_dashboard_table(
         dashboard=dashboard,
         force=force,
         skip_on_fail=skip_on_fail,
     )
 
-    # start by filtering in all the single tasks
-    results = metrics_table.keep_cols(*compiled_tasks)
-
-    # then iterate over named groups...
-    for named_group in named_groups:
-        # # This messes up with piping. Removing for now. -luca
-        # pprint(named_group.tasks)
-
-        # ...and try to combine them into a single score. Note we are giving it the full metrics table,
-        # not the one after filtering to single tasks.
-        combined_table = named_group.combine(metrics_table)
-
-        if combined_table is not None:
-            # we manage to combine! lets put the combined score at the front
-            results = combined_table + results
-        else:
-            # this cannot be combined. let's add each metric as a column. make sure not
-            # to include duplicates.
-            named_group_table = metrics_table.keep_cols(*named_group.expanded_tasks)
-            existing_columns = set(results.columns)
-            named_group_table_only_new_columns = named_group_table.keep_cols(
-                *(c for c in named_group_table.columns if c not in existing_columns)
-            )
-
-            # we add the new columns to the end of the table
-            results = results + named_group_table_only_new_columns
-
-    # we filtered tasks, but the user might want to display only some models
-    rows_filter_models: list[str | re.Pattern] = []
-    if len(models) > 0:
-        # okay we filter models too! do the same regex trick as above
-        rows_filter_models.extend(re.compile(m) if re.escape(m) != m else m for m in models)
-        results = results.keep_rows(*rows_filter_models)
-
-    missing_tasks: dict[str, list[str]] = {}
-    for model_row in results.rows:
-        for metric_column_name, metric_column_value in zip(model_row.columns, model_row.values):
-            # check if any of the values are None; if all values are there, this metric is ok,
-            # we have all results!
-            if metric_column_value is not None:
-                continue
-
-            all_tasks_set = set()
-            try:
-                # this is a task group! the get function will return a class that has an expanded_tasks attribute
-                all_tasks_set.update(NamedTasksGroupRegistry.get(metric_column_name).expanded_tasks)
-            except ValueError:
-                # actually not a task group, just a task name. append as is.
-                all_tasks_set.add(metric_column_name)
-
-            # add missing tasks to the missing_tasks dict
-            missing_tasks.setdefault(model_row.name, []).extend(all_tasks_set)
-
-    # we gotta let the user know if there are any missing tasks
-    print_missing_tasks(
-        missing_tasks=missing_tasks,
-        rows_filter_models=rows_filter_models,
-        columns_filter_tasks=columns_filter_tasks,
+    # we subselect the right tasks and models, plus expand named tasks
+    results = make_results_from_dashboard(
+        dashboard_table=dashboard_table,
+        tasks=tasks,
+        models=models,
     )
 
-    if format == 'return_missing':
-        return missing_tasks
+    # we find missing tasks in the results
+    missing_tasks = find_missing_tasks(results=results)
+
+    # we gotta let the user know if there are any missing tasks
+    print_missing_tasks(missing_tasks=missing_tasks, models=models, tasks=tasks)
 
     # okay we got all results! now time to sort them depending on the user's request
     try:
@@ -642,7 +575,7 @@ def get_results(
 
     # output according to format requested by the user
     if format == "json":
-        print(json.dumps(results._data))
+        print(results.to_json())
     elif format == "table":
         results.show()
     elif format == "csv":
@@ -660,8 +593,19 @@ def get_results(
     required=True,
     help="Models to add to the dashboard",
 )
-def add_to_dashboard(dashboard: str, models: list[str]) -> None:
-    resp = AddToDashboard.prun(dashboard=[dashboard for _ in models], model_name=list(models))
+@click.option(
+    "-s",
+    "--source-dashboard",
+    type=str,
+    help="Optional argument: if provided, only copy results from this dashboard",
+    default=None,
+)
+def add_to_dashboard(dashboard: str, models: list[str], source_dashboard: str | None) -> None:
+    resp = AddToDashboard.prun(
+        dashboard=[dashboard for _ in models],
+        model_name=list(models),
+        source_dashboard=[source_dashboard for _ in models],
+    )
     print(f"Added {len(resp)} models to the dashboard")
 
 
@@ -695,7 +639,7 @@ def list_tasks(task: list[str] | None):
         else:
             return task_target == task_source
 
-    table = Table(title=f"Listing named tasks")
+    table = Table(title="Listing named tasks")
     table.add_column("Group")
     table.add_column("Tasks")
     table.add_column("Count")

--- a/src/cookbook/eval/datalake.py
+++ b/src/cookbook/eval/datalake.py
@@ -398,7 +398,6 @@ class AddToDashboard(BaseDashboardTransformRequest):
             fn = partial(cls._endpoint_request, experiment_id=run.experiment_id, tags=new_tags, overwrite=False)
             fns.append(fn)
 
-        breakpoint()
         print(f"Adding {len(fns):,} experiments to dashboard {dashboard}")
 
         if (n := cls._thread_number()) >= 0:

--- a/src/cookbook/eval/datalake.py
+++ b/src/cookbook/eval/datalake.py
@@ -7,18 +7,22 @@ from dataclasses import field as dataclass_field
 from dataclasses import fields as dataclass_fields
 from datetime import datetime
 from functools import partial
+import logging
 from sys import stderr
 from threading import current_thread, main_thread
 from typing import Callable, ClassVar, Generic, List, TypeVar
 
+import os
 import requests
 from tqdm import tqdm
 from typing_extensions import Self
-
 from cookbook.eval.cache import get_datalake_cache
 
 T = TypeVar("T")
 V = TypeVar("V")
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -32,15 +36,21 @@ class BaseDatalakeItem(Generic[T]):
             if (parser := field.metadata.get("parser", None)) is not None:
                 setattr(self, field.name, parser(getattr(self, field.name)))
 
+    @classmethod
+    def num_workers(cls, num_workers: int | None = None) -> int | None:
+        if num_workers is None:
+            num_workers = int(w) if (w := os.environ.get("OE_EVAL_WORKERS", None)) is not None else None
+        return num_workers
+
     @staticmethod
     def _thread_number() -> int:
         if current_thread() == main_thread():
-            return 0
+            return -1
         else:
             return int(current_thread().name.split("-")[-1])
 
     @classmethod
-    def run(cls, **kwargs: T) -> List[Self]:
+    def run(cls, *args: T, **kwargs: T) -> List[Self]:
         """Run a query to retrieve one or more datalake items of this type."""
         raise NotImplementedError("Subclasses must implement this method")
 
@@ -57,9 +67,10 @@ class BaseDatalakeItem(Generic[T]):
             return []
 
         results: list[V] = []
+
         with ExitStack() as stack:
             # Set up thread pool and progress bar
-            pool = stack.enter_context(ThreadPoolExecutor(max_workers=num_workers))
+            pool = stack.enter_context(ThreadPoolExecutor(max_workers=cls.num_workers(num_workers)))
             pbar = stack.enter_context(
                 tqdm(total=len(fns), desc=cls.__name__, disable=quiet, file=stderr, position=position)
             )
@@ -102,7 +113,7 @@ class BaseDatalakeItem(Generic[T]):
         fns = [partial(cls.run, **{k: v[i] for k, v in kwargs.items()}) for i in range(num_args)]
 
         # actually run the function in parallel
-        results = cls._prun(fns=fns, num_workers=num_workers, quiet=quiet)
+        results = cls._prun(fns=fns, num_workers=cls.num_workers(num_workers), quiet=quiet)
         return [result for result_group in results for result in result_group]
 
 
@@ -272,10 +283,18 @@ class MetricsAll(BaseDatalakeItem):
 
 
 @dataclass
-class RemoveFromDashboard(BaseDatalakeItem):
-    """Remove an experiment from a dashboard."""
+class BaseDashboardTransformRequest(BaseDatalakeItem):
+    """Base class for dashboard requests."""
 
     _endpoint: ClassVar[str] = "bluelake/add-experiment-tags/"
+
+    @classmethod
+    def num_workers(cls, num_workers: int | None = None) -> int | None:
+        logger.warning(
+            "\033[1;33mlimiting num_workers to 1 (asked: %s) for dashboard requests\033[0m",
+            num_workers or "unlimited"
+        )
+        return 1
 
     @classmethod
     def _endpoint_request(cls, experiment_id: str, tags: list[Tag], overwrite: bool = True) -> Self:
@@ -297,8 +316,20 @@ class RemoveFromDashboard(BaseDatalakeItem):
         response.raise_for_status()
         return cls(**(response.json() or {}))
 
+
+
+@dataclass
+class RemoveFromDashboard(BaseDashboardTransformRequest):
+    """Remove an experiment from a dashboard."""
+
     @classmethod
-    def run(cls, model_name: str, dashboard: str, fuzzy: bool = False) -> List[Self]:
+    def run(
+        cls,
+        model_name: str,
+        dashboard: str,
+        fuzzy: bool = False,
+        num_workers: int | None = None
+    ) -> List[Self]:
         runs = FindExperiments.run(model_name=model_name, dashboard=dashboard)
         cache = get_datalake_cache()
 
@@ -315,23 +346,30 @@ class RemoveFromDashboard(BaseDatalakeItem):
             fn = partial(cls._endpoint_request, experiment_id=run.experiment_id, tags=new_tags, overwrite=True)
             fns.append(fn)
 
-        print(f"Removing {len(runs):,} experiments from dashboard {dashboard}")
+        print(f"Removing {len(fns):,} experiments from dashboard {dashboard}")
 
-        if (n := cls._thread_number()) > 0:
+        if (n := cls._thread_number()) >= 0:
             # if we are already running in parallel, then we can use _prun() to create more parallelism
             # (we avoid making a second progress bar by setting quiet=True)
-            return cls._prun(fns=fns, num_workers=len(runs), position=n)
+            return cls._prun(fns=fns, num_workers=num_workers, position=n)
         else:
             # if we are single-threaded, then we can just run the function sequentially
             return [fn() for fn in fns]
 
 
 @dataclass
-class AddToDashboard(RemoveFromDashboard):
+class AddToDashboard(BaseDashboardTransformRequest):
     """Add an experiment to a dashboard."""
 
     @classmethod
-    def run(cls, model_name: str, dashboard: str, fuzzy: bool = False) -> List[Self]:
+    def run(
+        cls,
+        model_name: str,
+        dashboard: str,
+        source_dashboard: str | None = None,
+        fuzzy: bool = False,
+        num_workers: int | None = None,
+    ) -> List[Self]:
         runs = FindExperiments.run(model_name=model_name)
         cache = get_datalake_cache()
         fns = []
@@ -346,17 +384,27 @@ class AddToDashboard(RemoveFromDashboard):
             if any(tag.key == "dashboard" and tag.value == dashboard for tag in run.tags):
                 continue
 
+            if source_dashboard:
+                # check if the current run has the right source dashboard tag
+                if not any(tag.key == "dashboard" and tag.value == source_dashboard for tag in run.tags):
+                    continue
+
+            if "winogrande" not in run.task_name:
+                continue
+            print(run)
+
             # if it is not present, then we add it
             new_tags = [Tag(key="dashboard", value=dashboard)]
             fn = partial(cls._endpoint_request, experiment_id=run.experiment_id, tags=new_tags, overwrite=False)
             fns.append(fn)
 
-        print(f"Adding {len(runs):,} experiments to dashboard {dashboard}")
+        breakpoint()
+        print(f"Adding {len(fns):,} experiments to dashboard {dashboard}")
 
-        if (n := cls._thread_number()) > 0:
+        if (n := cls._thread_number()) >= 0:
             # if we are already running in parallel, then we can use _prun() to create more parallelism
             # (we avoid making a second progress bar by setting quiet=True)
-            return cls._prun(fns=fns, num_workers=len(runs), position=n)
+            return cls._prun(fns=fns, num_workers=num_workers, position=n)
         else:
             # if we are single-threaded, then we can just run the function sequentially
             return [fn() for fn in fns]

--- a/src/cookbook/eval/miniframe.py
+++ b/src/cookbook/eval/miniframe.py
@@ -1,4 +1,5 @@
 import re
+import json
 from collections import OrderedDict
 from dataclasses import dataclass, field
 from functools import partial
@@ -147,6 +148,9 @@ class MiniFrame:
             table.add_row(row.name, *formatted_values)
 
         console.print(table)
+
+    def to_json(self) -> str:
+        return json.dumps(self._data, sort_keys=True)
 
     def to_csv(self) -> str:
         # Header row with just column names, sorted alphabetically

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -112,13 +112,7 @@ class BaseAverageNamedTasksGroup(BaseNamedTasksGroup):
 
     def combine(self, results: MiniFrame) -> MiniFrame | None:
         filtered_rows = results.keep_cols(*self.expanded_tasks)
-
         combined_table = MiniFrame(title=results.title)
-
-        # Add empty values to all tasks
-        for row in results.rows:
-            for task in self.expanded_tasks:
-                combined_table.add(col=task, row=row.name, val=None)
 
         # each row here is a model
         for row in filtered_rows.rows:
@@ -184,12 +178,12 @@ class BaseAverageOfAveragesNamedTasksGroup(BaseAverageNamedTasksGroup):
             filtered_rows.add(col=self.name, row=row.name, val=average)
 
         return filtered_rows
-    
+
 
 class BaseTaskView(BaseAverageOfAveragesNamedTasksGroup):
     """
-    Base class for tasks "views". In a task view, only the child tasks are averages 
-    
+    Base class for tasks "views". In a task view, only the child tasks are averages
+
     For example, "olmo3:dev:7b:main" is not a average, but contains "olmo3:dev:7b:mcqa" and "mmlu:mc" are task averages.
     """
     def combine(self, results: MiniFrame) -> MiniFrame | None:
@@ -353,7 +347,7 @@ class MinervaHamishZSReasoningGroup(BaseAverageNamedTasksGroup):
 @NamedTasksGroupRegistry.register("math")
 class MathGroup(BaseAverageNamedTasksGroup):
     tasks = [
-        "gsm8k::olmo1", 
+        "gsm8k::olmo1",
         "gsm8k::olmes",
         [f"{subtask}::olmes" for subtask in constants.ALL_MINERVA_TASKS]
     ]

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -2,9 +2,14 @@ from datetime import datetime
 import logging
 import re
 import sys
+from typing import NamedTuple
 
 from cookbook.eval.datalake import FindExperiments, MetricsAll
 from cookbook.eval.miniframe import MiniFrame
+from cookbook.eval.named_tasks import (
+    BaseNamedTasksGroup,
+    NamedTasksGroupRegistry,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +37,8 @@ def make_bpb_name(alias: str) -> str | None:
 def make_dashboard_table(
     dashboard: str,
     force: bool = False,
-    skip_on_fail: bool = False,
-) -> tuple[MiniFrame, dict[str, list[str]]]:
+    skip_on_fail: bool = True,
+) -> MiniFrame:
     experiments = FindExperiments.run(dashboard=dashboard)
 
     logger.info(f"Found {len(experiments)} experiments in dashboard {dashboard}")
@@ -101,17 +106,128 @@ def make_dashboard_table(
     return metrics_table
 
 
+class ExpandedTasks(NamedTuple):
+    single_tasks: list[str | re.Pattern]
+    named_groups: list[BaseNamedTasksGroup]
+    all_column_tasks: list[str | re.Pattern]
+
+    @classmethod
+    def from_tasks(cls, tasks: list[str]) -> 'ExpandedTasks':
+        # compile tasks names into regex patterns (if possible)
+        compiled_tasks = [re.compile(task) if re.escape(task) != task else task for task in tasks]
+
+        # we partition between single tasks and named groups; we also keep a set of all tasks names,
+        # which we will use later to print any missing tasks.
+        named_groups: list[BaseNamedTasksGroup] = []
+        columns_filter_tasks: list[str | re.Pattern] = compiled_tasks[:]
+        for compiled_task in compiled_tasks:
+            matching_groups = [
+                NamedTasksGroupRegistry.get(ng) for ng in NamedTasksGroupRegistry.search(compiled_task)
+            ]
+            named_groups.extend(matching_groups)
+            columns_filter_tasks.extend(t for ng in matching_groups for t in ng.expanded_tasks)
+
+        return cls(
+            single_tasks=compiled_tasks,
+            named_groups=named_groups,
+            all_column_tasks=columns_filter_tasks,
+        )
+
+
+class ExpandedModels(NamedTuple):
+    single_models: list[str | re.Pattern]
+
+    @classmethod
+    def from_models(cls, models: list[str]) -> 'ExpandedModels':
+        # we filtered tasks, but the user might want to display only some models
+        rows_filter_models: list[str | re.Pattern] = []
+        if len(models) > 0:
+            # okay we filter models too! do the same regex trick as above
+            rows_filter_models.extend(re.compile(m) if re.escape(m) != m else m for m in models)
+
+        return cls(single_models=rows_filter_models)
+
+
+def make_results_from_dashboard(
+    dashboard_table: MiniFrame,
+    tasks: list[str],
+    models: list[str] | None = None
+) -> MiniFrame:
+    """
+    Filter the results table based on the tasks and models provided.
+    """
+    expanded_tasks = ExpandedTasks.from_tasks(tasks)
+    expanded_models = ExpandedModels.from_models(models or [])
+
+    # start by filtering in all the single tasks
+    results = dashboard_table.keep_cols(*expanded_tasks.single_tasks)
+
+    # then iterate over named groups...
+    for named_group in expanded_tasks.named_groups:
+        # ...and try to combine them into a single score. Note we are giving it the full metrics table,
+        # not the one after filtering to single tasks.
+        combined_table = named_group.combine(dashboard_table)
+
+        if combined_table is not None:
+            # we manage to combine! lets put the combined score at the front
+            results = combined_table + results
+        else:
+            # this cannot be combined. let's add each metric as a column. make sure not
+            # to include duplicates.
+            named_group_table = dashboard_table.keep_cols(*named_group.expanded_tasks)
+            existing_columns = set(results.columns)
+            named_group_table_only_new_columns = named_group_table.keep_cols(
+                *(c for c in named_group_table.columns if c not in existing_columns)
+            )
+
+            # we add the new columns to the end of the table
+            results = results + named_group_table_only_new_columns
+
+    if expanded_models.single_models:
+        results = results.keep_rows(*expanded_models.single_models)
+
+    return results
+
+
+def find_missing_tasks(results: MiniFrame) -> dict[str, list[str]]:
+    """ Looks for columns that are set to None across all models (rows) in the results"""
+
+    missing_tasks: dict[str, list[str]] = {}
+    for model_row in results.rows:
+        for metric_column_name, metric_column_value in zip(model_row.columns, model_row.values):
+            # check if any of the values are None; if all values are there, this metric is ok,
+            # we have all results!
+            if metric_column_value is not None:
+                continue
+
+            all_tasks_set = set()
+            try:
+                # this is a task group! the get function will return a class that has an expanded_tasks attribute
+                all_tasks_set.update(NamedTasksGroupRegistry.get(metric_column_name).expanded_tasks)
+            except ValueError:
+                # actually not a task group, just a task name. append as is.
+                all_tasks_set.add(metric_column_name)
+
+            # add missing tasks to the missing_tasks dict
+            missing_tasks.setdefault(model_row.name, []).extend(all_tasks_set)
+
+    return missing_tasks
+
+
 def print_missing_tasks(
     missing_tasks: dict[str, list[str]],
-    rows_filter_models: list[str | re.Pattern],
-    columns_filter_tasks: list[str | re.Pattern],
+    tasks: list[str],
+    models: list[str] | None = None,
 ) -> None:
+
+    expanded_tasks = ExpandedTasks.from_tasks(tasks)
+    expanded_models = ExpandedModels.from_models(models or [])
 
     # go through the missing models and tasks and print them out
     for model, missing_task in missing_tasks.items():
         # filter to only models user requested
-        if rows_filter_models and not any(
-            m.search(model) if isinstance(m, re.Pattern) else m == model for m in rows_filter_models
+        if expanded_models.single_models and not any(
+            m.search(model) if isinstance(m, re.Pattern) else m == model for m in expanded_models.single_models
         ):
             continue
 
@@ -119,7 +235,10 @@ def print_missing_tasks(
         model_missing_tasks = {
             task
             for task in missing_task
-            if any(t.search(task) if isinstance(t, re.Pattern) else t == task for t in columns_filter_tasks)
+            if any(
+                t.search(task) if isinstance(t, re.Pattern) else t == task
+                for t in expanded_tasks.all_column_tasks
+            )
         }
         if not model_missing_tasks:
             continue


### PR DESCRIPTION
This PR achieves two goals:

- It improves API for adding/removing runs from dashboard by adding limits on concurrency and providing more logging
- It moves and partition functions to pull results so they are all in `src/cookbook/eval/results.py`; this improves legibility, and remove the slight abuse of `get_results(...)` function in `src/cookbook/cli/eval.py` in `backfill` mode for `evaluate_model`.
- It fixes phantom runs [reported by @kyleclo](https://allenai.slack.com/archives/C04S826K6KX/p1752210015400599)

Note: many dashboard/datalake functions are broken for models that rely on `--revision`, due to the fact that the revision string is not encoded in the run name. I'm choosing to leave as-is, noting that experiment that rely on revision might cause results to not show up properly, and cannot be moved between dashboard. This ought to be fixed in future runs via breaking changes. 