### PR TITLE
fix name of agi eval tasks

### DIFF
--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -407,15 +407,15 @@ BASIC_SKILLS = [
 ]
 
 AGI_EVAL_ENGLISH_TASKS = [
-    "lsat-ar",
-    "lsat-lr",
-    "lsat-rc",
-    "logiqa-en",
-    "sat-math",
-    "sat-en",
-    "aqua-rat",
-    "sat-en-without-passage",
-    "gaokao-english",
+    "agi_eval_lsat-ar",
+    "agi_eval_lsat-lr",
+    "agi_eval_lsat-rc",
+    "agi_eval_logiqa-en",
+    "agi_eval_sat-math",
+    "agi_eval_sat-en",
+    "agi_eval_aqua-rat",
+    "agi_eval_sat-en-without-passage",
+    "agi_eval_gaokao-english",
 ]
 
 BBH_TASKS = [


### PR DESCRIPTION
Example of bug:
```
2025-08-07T00:08:06.538Z INFO 08-06 17:08:06 [__init__.py:243] Automatically detected platform cuda.
2025-08-07T00:08:10.792Z 2025-08-06:17:08:10,790 INFO     [rouge_scorer.py:83] Using default tokenizer.
2025-08-07T00:08:11.839Z Traceback (most recent call last):
2025-08-07T00:08:11.839Z   File "<frozen runpy>", line 198, in _run_module_as_main
2025-08-07T00:08:11.839Z   File "<frozen runpy>", line 88, in _run_code
2025-08-07T00:08:11.839Z   File "/stage/oe_eval/run_eval.py", line 1084, in <module>
2025-08-07T00:08:11.839Z     run_eval(args_dict)
2025-08-07T00:08:11.839Z   File "/stage/oe_eval/run_eval.py", line 578, in run_eval
2025-08-07T00:08:11.839Z     task_objects = [
2025-08-07T00:08:11.839Z                    ^
2025-08-07T00:08:11.839Z   File "/stage/oe_eval/run_eval.py", line 579, in <listcomp>
2025-08-07T00:08:11.839Z     load_task(task_config, compute_config["output_dir"]) for task_config in tasks_config
2025-08-07T00:08:11.839Z     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-08-07T00:08:11.839Z   File "/stage/oe_eval/run_eval.py", line 424, in load_task
2025-08-07T00:08:11.839Z     raise ValueError(f"Task {task_name} not found in the task registry!")
2025-08-07T00:08:11.839Z ValueError: Task sat-en-without-passage:1shot::olmes not found in the task registry!
```

this fixes