### PR TITLE
Ignore `*.code-workspace` files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,7 @@ cython_debug/
 tmp/
 temp/
 uv.lock
+
+
+# ignore vscode workspace settings
+*.code-workspace


### PR DESCRIPTION
These are used to config personal workspace on local dev environment. 