### PR TITLE
Handle HF Token for evals that require it; upgrade Gantry to support aliases.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tabulate",
     "packaging>=24.2",
     "tqdm>=4.67.1",
+    "huggingface-hub[hf-transfer]>=0.34,<0.35",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
     "google-api-python-client-stubs",
 ]
 beaker = [
-    "beaker-py>=1,<2",
+    "beaker-py>=1.17.1,<2",
     "GitPython>=3.0,<4.0",
 ]
 wandb = [
@@ -49,7 +49,7 @@ checkpoints = [
 ]
 all = [
     "ai2-olmo-core @ git+https://github.com/allenai/OLMo-core.git@7afdc3ed67f00b090aae11b5101ef147160274cc", #c779ca546cc3194e73e7491aaefcdffbed042c65",
-    "beaker-py>=1,<2",
+    "beaker-py>=1.17.1,<2",
     "GitPython>=3.0,<4.0",
     "wandb",
 ]

--- a/src/cookbook/cli/eval.py
+++ b/src/cookbook/cli/eval.py
@@ -339,6 +339,12 @@ def convert_checkpoint(
 )
 @click.option("-n", "--num-gpus", type=int, default=1, help="Set number of GPUs")
 @click.option(
+    "--use-hf-token/--no-use-hf-token",
+    default=False,
+    type=bool,
+    help="If true, always mount huggingface token as beaker secret",
+)
+@click.option(
     "-x",
     "--extra-args",
     type=str,
@@ -510,6 +516,7 @@ def evaluate_model(
     remote_output_prefix: str,
     extra_args: str,
     batch_size: int,
+    use_hf_token: bool,
     dry_run: bool,
     beaker_image: str,
     beaker_retries: int,
@@ -601,6 +608,7 @@ def evaluate_model(
         dashboard=dashboard,
         model_backend=model_backend,
         tasks=tasks,
+        use_hf_token=use_hf_token,
         partition_size=partition_size,
         remote_output_prefix=remote_output_prefix,
         extra_args=extra_args,

--- a/src/cookbook/constants.py
+++ b/src/cookbook/constants.py
@@ -1,5 +1,3 @@
-import json
-
 TRANSFORMERS_GIT_URL = "https://github.com/huggingface/transformers.git"
 TRANSFORMERS_COMMIT_HASH = "241c04d36867259cdf11dbb4e9d9a60f9cb65ebc"  # v4.47.1
 
@@ -29,8 +27,8 @@ BEAKER_DEFAULT_WORKSPACE = "ai2/oe-data"
 BEAKER_DEFAULT_BUDGET = "ai2/oe-base"
 BEAKER_DEFAULT_PRIORITY = "normal"
 
-BEAKER_PY_MAX_VERSION = "1.34.1"
-BEAKER_GANTRY_MAX_VERSION = "1.14.1"
+BEAKER_PY_MAX_VERSION = "1.36.4"
+BEAKER_GANTRY_MAX_VERSION = "1.17.1"
 
 OLMO_TYPES = ["olmoe", "olmo2", "olmo-core", "olmo-core-v2"]
 
@@ -81,6 +79,34 @@ BEAKER_KNOWN_CLUSTERS = {
         "ai2/ceres-cirrascale",
     ],
 }
+
+NEW_CLUSTER_ALIASES = {
+    "ai2/allennlp": "ai2/allennlp-elanding-a100-40g",
+    "ai2/allennlp-dev-a100-sea": "ai2/allennlp-elanding-a100-40g",
+    "ai2/augusta-batch-h100-dsm-tcpxo": "ai2/augusta-google-1",
+    "ai2/augusta":"ai2/augusta-google-1",
+    "ai2/ceres-dev-h100-aus-ib": "ai2/ceres-cirrascale",
+    "ai2/ceres":"ai2/ceres-cirrascale",
+    "ai2/jupiter-batch-h100-aus-ib": "ai2/jupiter-cirrascale-2",
+    "ai2/jupiter":"ai2/jupiter-cirrascale-2",
+    "ai2/neptune-dev-l40-aus": "ai2/neptune-cirrascale",
+    "ai2/neptune":"ai2/neptune-cirrascale",
+    "ai2/phobos-dev-aus": "ai2/phobos-cirrascale",
+    "ai2/phobos":"ai2/phobos-cirrascale",
+    "ai2/prior-dev-a6000-sea": "ai2/prior-elanding",
+    "ai2/prior":"ai2/prior-elanding",
+    "ai2/prior-rtx8000":"ai2/prior-elanding-rtx8000",
+    "ai2/prior-dev-rtx8000-sea": "ai2/prior-elanding-rtx8000",
+    "ai2/rhea-dev-a6000-aus": "ai2/rhea-cirrascale",
+    "ai2/rhea":"ai2/rhea-cirrascale",
+    "ai2/saturn-dev-a100-aus": "ai2/saturn-cirrascale",
+    "ai2/saturn":"ai2/saturn-cirrascale",
+    "ai2/titan-batch-b200-aus-ib": "ai2/titan-cirrascale",
+    "ai2/titan":"ai2/titan-cirrascale",
+    "ai2/triton-dev-l40-aus": "ai2/triton-cirrascale",
+    "ai2/triton":"ai2/triton-cirrascale",
+}
+
 
 MMLU_CATEGORIES = [
     "mmlu_abstract_algebra",

--- a/src/cookbook/eval/conversion.py
+++ b/src/cookbook/eval/conversion.py
@@ -20,7 +20,6 @@ from cookbook.cli.utils import (
     remove_conflicting_packages,
 )
 from cookbook.constants import (
-    BEAKER_KNOWN_CLUSTERS,
     DEFAULT_OLMO2_TOKENIZER,
     DEFAULT_OLMO_CORE_TOKENIZER,
     DEFAULT_OLMOE_TOKENIZER,
@@ -34,6 +33,7 @@ from cookbook.constants import (
     OLMOE_UNSHARD_SCRIPT,
     TRANSFORMERS_COMMIT_HASH,
 )
+from cookbook.utils.clusters import get_matching_clusters
 
 
 def convert_olmo_core_v2(
@@ -48,12 +48,12 @@ def convert_olmo_core_v2(
     transformers_git_url: Optional[str] = None,
     transformers_commit_hash: str = TRANSFORMERS_COMMIT_HASH,
     skip_validation: bool = False,
+    fix_generation_config: bool = True,
     dtype: Optional[str] = None,
     env: Optional[PythonEnv] = None,
 ):
     env = env or PythonEnv.null()
 
-    current_directory = os.getcwd()
     directories_to_clean_up = []
 
     if max_sequence_length is None:
@@ -150,11 +150,62 @@ def convert_olmo_core_v2(
             config = json.load(f)
 
         if config.get("torch_dtype", "") == "float32":
-            print(f"Changing type of model to bfloat16...")
+            print("Changing type of model to bfloat16...")
             config["torch_dtype"] = "bfloat16"
 
             with open(config_file, "w") as f:
                 json.dump(config, f)
+
+            print(f"Updated model type from float32 to bfloat16 in {config_file}.")
+
+        if fix_generation_config:
+            # fix generation config
+            generation_config_file = os.path.join(huggingface_output_dir, "generation_config.json")
+            tokenization_config_file = os.path.join(huggingface_output_dir, "tokenizer_config.json")
+            tokenizer_file = os.path.join(huggingface_output_dir, "tokenizer.json")
+
+            generation_config = {}
+            if os.path.exists(generation_config_file):
+                with open(generation_config_file, "r") as f:
+                    generation_config = json.load(f)
+            assert isinstance(generation_config, dict), "generation_config.json should be a dictionary"
+
+            if "eos_token_id" in generation_config and "pad_token_id" not in generation_config:
+                print("EOS and PAD tokens already set in generation config, nothing to do.")
+                return
+
+            if not os.path.exists(tokenization_config_file):
+                raise FileNotFoundError("tokenization_config.json not found; cannot fix generation config.")
+
+            with open(tokenization_config_file, "r") as f:
+                tokenization_config = json.load(f)
+
+            if not os.path.exists(tokenizer_file):
+                raise FileNotFoundError("tokenizer.json not found; cannot fix generation config.")
+
+            with open(tokenizer_file, "r") as f:
+                tokenizer = json.load(f)
+
+            # TODO: bos too?
+            for token_name in ("eos_token", "pad_token"):
+                token_id_name = f"{token_name}_id"
+                if token_id_name in generation_config:
+                    print(f"Checking EOS token ID in generation config: {generation_config['eos_token_id']}")
+                    continue
+
+                if (token_value := tokenization_config.get(token_name)) is None:
+                    continue
+
+                token_id_value = tokenizer.get("model", {}).get("vocab", {}).get(token_value, None)
+                if token_id_value is None:
+                    raise ValueError(f"Could not find {token_id_name} for {token_value} in {tokenizer_file}.")
+                print(f"Setting {token_id_name} to {token_id_value} in generation config.")
+                generation_config[token_id_name] = token_id_value
+
+            with open(generation_config_file, "w") as f:
+                json.dump(generation_config, f, indent=2)
+
+            print(f"Updated generation config in {generation_config_file}.")
 
     finally:
         for directory in directories_to_clean_up:
@@ -469,11 +520,18 @@ def run_checkpoint_conversion(
             if secret_name:
                 gantry_flags.append(f"--env-secret HF_TOKEN={secret_name}")
 
-        for cluster in BEAKER_KNOWN_CLUSTERS.get(beaker_cluster, [beaker_cluster]):
+        for cluster in get_matching_clusters(beaker_cluster):
             gantry_flags.append(f"--cluster {cluster}")
+
+        install_flash_attention = (
+            "uv sync --no-build-isolation-package flash-attn &&"
+            if olmo_type == "olmo-core-v2"
+            else ""
+        )
 
         remote_command = [
             "pip install uv && uv pip install . --system &&",
+            install_flash_attention,
             "olmo-cookbook-eval convert",
             f"{input_dir}",
             f"--olmo-type {olmo_type}",

--- a/src/cookbook/eval/conversion_from_hf.py
+++ b/src/cookbook/eval/conversion_from_hf.py
@@ -15,11 +15,11 @@ from cookbook.cli.utils import (
     remove_conflicting_packages,
 )
 from cookbook.constants import (
-    BEAKER_KNOWN_CLUSTERS,
     OLMO_CORE_CONVERT_FROM_HF_SCRIPT,
     OLMO_CORE_V2_COMMIT_HASH,
     TRANSFORMERS_COMMIT_HASH,
 )
+from cookbook.utils.clusters import get_matching_clusters
 
 
 def convert_hf_to_olmo_core_v2(
@@ -161,7 +161,7 @@ def run_checkpoint_conversion_from_hf(
             if secret_name:
                 gantry_flags.append(f"--env-secret HF_TOKEN={secret_name}")
 
-        for cluster in BEAKER_KNOWN_CLUSTERS.get(beaker_cluster, [beaker_cluster]):
+        for cluster in get_matching_clusters(beaker_cluster):
             gantry_flags.append(f"--cluster {cluster}")
 
         remote_command = [

--- a/src/cookbook/eval/evaluation.py
+++ b/src/cookbook/eval/evaluation.py
@@ -16,13 +16,12 @@ from cookbook.cli.utils import (
     make_eval_run_name,
 )
 from cookbook.constants import (
-    BEAKER_KNOWN_CLUSTERS,
     FIM_TOKENS,
     OE_EVAL_LAUNCH_COMMAND,
     WEKA_MOUNTS,
 )
 from cookbook.eval.named_tasks import NamedTasksGroupRegistry
-
+from cookbook.utils.clusters import get_matching_clusters, is_gcs_cluster
 
 def evaluate_checkpoint(
     oe_eval_commit: str,
@@ -62,6 +61,7 @@ def evaluate_checkpoint(
     use_backend_in_run_name: bool,
     name_suffix: str,
     num_shots: int | None,
+    use_hf_token: bool,
 ):
     # Create virtual environment
     env = PythonEnv.create(name=python_venv_name, force=python_venv_force)
@@ -70,8 +70,10 @@ def evaluate_checkpoint(
     # Install oe-eval toolkit
     oe_eval_dir = install_oe_eval(
         env=env,
-        commit_hash=oe_eval_commit,
-        commit_branch=oe_eval_branch,
+        # commit_hash=oe_eval_commit,
+        commit_hash=None,
+        # commit_branch=oe_eval_branch,
+        commit_branch=None,
         is_editable=use_gantry,
     )
 
@@ -104,7 +106,7 @@ def evaluate_checkpoint(
         # This is google cloud storage; for now, we just override cluster
         # so that it runs on augusta; credentials to fetch there are automatically
         # configured
-        if cluster != "goog" and cluster not in BEAKER_KNOWN_CLUSTERS["goog"]:
+        if not is_gcs_cluster(cluster):
             print(
                 "Checkpoint is stored in Google Cloud Storage, "
                 "but cluster is not set to 'goog'. Overriding cluster."
@@ -114,27 +116,16 @@ def evaluate_checkpoint(
         raise ValueError(f"Unsupported scheme '{scheme}' in checkpoint path")
     elif checkpoint_path.startswith("/weka/") or any(checkpoint_path.startswith(f"/{w}/") for w in WEKA_MOUNTS):
         print("Checkpoint is stored in Weka; I will remove cluster that have no WEKA.")
-        for cl in BEAKER_KNOWN_CLUSTERS["goog"]:
+        for cl in get_matching_clusters("goog"):
             clusters_to_exclude.add(cl)
 
         if checkpoint_path.startswith("/weka/"):
             checkpoint_path = f"weka://{checkpoint_path[6:].rstrip('/')}"
         else:
             checkpoint_path = f"weka://{checkpoint_path.lstrip('/').rstrip('/')}"
-
     else:
         print("Path is a huggingface hub model; I will add huggingface token to beaker workspace")
-        if huggingface_secret:
-            hf_token_secret = add_secret_to_beaker_workspace(
-                secret_name="HUGGING_FACE_HUB_TOKEN",
-                secret_value=huggingface_secret,
-                workspace=workspace,
-                env=env,  # pyright: ignore
-            )
-            flags.append(f"--gantry-secret-hf-read-only '{hf_token_secret}'")
-            gantry_args_dict = {"hf_token": "true", **gantry_args_dict}
-        else:
-            print("\n\nWARNING: Hugging Face token not provided; this may cause issues with model download.\n\n")
+        use_hf_token = True
 
     if use_backend_in_run_name:
         if name_suffix.strip():
@@ -152,7 +143,7 @@ def evaluate_checkpoint(
     )
 
     # replace nicknames for actual cluster names, joined with commas
-    beaker_clusters = ",".join(set(BEAKER_KNOWN_CLUSTERS.get(cluster, [cluster])).difference(clusters_to_exclude))
+    beaker_clusters = ",".join(set(get_matching_clusters(cluster)).difference(clusters_to_exclude))
 
     # set the beaker flags
     flags.append(f"--beaker-workspace '{workspace}'")
@@ -209,6 +200,35 @@ def evaluate_checkpoint(
         r"^.*:pass_at_.*$",
     ]
     all_tasks = [task for task in all_tasks if not any(re.match(pattern, task) for pattern in EXCLUDE_FROM_LAUNCH)]
+
+
+    # @soldni: these evals are known to be private, thus requiring HF token
+    HF_TOKEN_REQUIRED_TASKS = [
+        r"^squad"
+    ]
+    tasks_with_hf_tokens = [
+        task for task in all_tasks if any(re.search(pattern, task) for pattern in HF_TOKEN_REQUIRED_TASKS)
+    ]
+    if len(tasks_with_hf_tokens) > 0:
+        print(f"These evals require HF token: {tasks_with_hf_tokens}")
+        use_hf_token = True
+
+    # @soldni: switching to always push huggingface token to beaker workspace
+    if use_hf_token:
+        if huggingface_secret:
+            hf_token_secret = add_secret_to_beaker_workspace(
+                secret_name="HUGGING_FACE_HUB_TOKEN",
+                secret_value=huggingface_secret,
+                workspace=workspace,
+                env=env,  # pyright: ignore
+            )
+            flags.append(f"--gantry-secret-hf-read-only '{hf_token_secret}'")
+            gantry_args_dict = {"hf_token": "true", **gantry_args_dict}
+        else:
+            print(
+                "\n\nWARNING: Hugging Face token not provided; "
+                "this may cause issues with model download or evals.\n\n"
+            )
 
     # DOING SOME PRETTY PRINTING HERE #
     print(
@@ -309,6 +329,8 @@ def evaluate_checkpoint(
             gantry_args_dict = {
                 "env": f"VLLM_USE_V1={1 if use_vllm_v1_spec else 0}",
                 "yes": True,
+                **({"ref": oe_eval_commit} if oe_eval_commit else {}),
+                **({"branch": oe_eval_branch} if oe_eval_branch else {}),
                 **gantry_args_dict,
             }
 

--- a/src/cookbook/remote/gantry_launcher.py
+++ b/src/cookbook/remote/gantry_launcher.py
@@ -1,16 +1,13 @@
 import shlex
 import subprocess
 from dataclasses import InitVar, dataclass
-from typing import ClassVar, Optional
 
 from cookbook.cli.utils import (
     PythonEnv,
     add_secret_to_beaker_workspace,
-    discover_weka_mount,
     install_beaker_py,
-    remove_conflicting_packages,
 )
-from cookbook.constants import BEAKER_KNOWN_CLUSTERS
+from cookbook.utils.clusters import get_matching_clusters
 
 from .base import LocatedPath
 
@@ -34,7 +31,7 @@ class GantryLauncher:
         # setup beaker-py
         install_beaker_py(env=self._env)
 
-        for cluster in BEAKER_KNOWN_CLUSTERS.get(self.cluster, [self.cluster]):
+        for cluster in get_matching_clusters(self.cluster):
             self._flags.append(f"--cluster {cluster}")
 
     def add_mount(self, path: str):

--- a/src/cookbook/utils/clusters.py
+++ b/src/cookbook/utils/clusters.py
@@ -1,0 +1,39 @@
+from cookbook.constants import BEAKER_KNOWN_CLUSTERS, NEW_CLUSTER_ALIASES
+
+
+def get_matching_clusters(cluster: str) -> list[str]:
+    """
+    This function converts cluster aliases to the actual cluster names; it also
+    handles the cases where a cluster is referred to by an alias.
+    """
+    if cluster in NEW_CLUSTER_ALIASES:
+        cluster = NEW_CLUSTER_ALIASES[cluster]
+
+    if cluster in BEAKER_KNOWN_CLUSTERS:
+        return BEAKER_KNOWN_CLUSTERS[cluster]
+
+    return [cluster]
+
+
+def is_gcs_cluster(cluster: str) -> bool:
+    """
+    This function checks if a cluster has GCS support.
+    """
+
+    if cluster == "goog":
+        return True
+
+    if cluster in NEW_CLUSTER_ALIASES:
+        cluster = NEW_CLUSTER_ALIASES[cluster]
+
+    if cluster in BEAKER_KNOWN_CLUSTERS["goog"]:
+        return True
+
+    return False
+
+def get_known_clusters() -> list[str]:
+    """
+    This function returns all known clusters in OLMo Cookbook.
+    """
+    all_clusters = [c for cs in BEAKER_KNOWN_CLUSTERS.values() for c in cs]
+    return sorted(set(all_clusters))


### PR DESCRIPTION
This PR implements the following changes:

- Adds auto-push of Hugging Face Hub token for evals that require access to the Hub; see PR [here](https://github.com/allenai/oe-eval-internal/pull/642) for more info. So far, only squad evals require this, but I've also added a `--use-hf-token` flag to force always adding token. 
    - now this is a common use case, I've added `huggingface-hub` among dependencies for better token auto-discovery. 
- Beaker team is enabling [cluster aliases](https://docs.google.com/document/d/1aNShU0lywa9vjhnVQV_XWx9J3LB2_Z2NF7zCSHIHCJI/edit?tab=t.0#heading=h.kcn3d9ewlzew) on 09/02, which requires updating Beaker Gantry client. This PR does that. 