### PR TITLE
Add `olmo3:dev:1b:qa:bpb`

### DIFF
--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -309,6 +309,11 @@ class ARCMCXlargeGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{category}:mc::xlarge" for category in constants.ARC_TASKS]
 
 
+@NamedTasksGroupRegistry.register("basic:bpb")
+class BasicBpbGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"{task}:bpb::olmes" for task in constants.BASIC_SKILLS]
+
+
 @NamedTasksGroupRegistry.register("basic:rc")
 class BasicRCGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{task}:rc::olmes" for task in constants.BASIC_SKILLS]
@@ -601,7 +606,7 @@ class Olmo3Dev1bQaBpbGroup(BaseAverageOfAveragesNamedTasksGroup):
         # New OLMo 3
         "sciq:bpb::olmo3",
         "qasper_yesno:bpb::olmes",
-        "basic_skills:bpb::olmes",
+        BasicBpbGroup(),
         "lab_bench_dbqa:bpb",
         "lab_bench_protocolqa:bpb",
         "lambada:bpb",
@@ -646,40 +651,14 @@ class Olmo3Dev1bQaRcGroup(BaseAverageOfAveragesNamedTasksGroup):
 @NamedTasksGroupRegistry.register("olmo3:dev:1b:bpb")
 class Olmo3Dev1bBpbGroup(BaseAverageOfAveragesNamedTasksGroup):
     tasks = [
-        # Core OLMES
-        "arc:bpb::full$",
-        "mmlu:bpb$",
-        "csqa:bpb::olmes:full",
-        "hellaswag:bpb::olmes:full",
-        "winogrande:bpb::olmes:full",
-        "socialiqa:bpb::olmes:full",
-        "piqa:bpb::olmes:full",
-
-        # Gen OLMES
-        "coqa:bpb::gen2mc",
-        "drop:bpb::gen2mc",
-        "jeopardy:bpb::gen2mc",
-        "naturalqs:bpb::gen2mc",
-        "squad:bpb::gen2mc",
+        # QA
+        Olmo3Dev1bQaBpbGroup(),
 
         # Math
         MinervaBpbGroup(),
 
         # Code
         Olmo3Dev1bCodeBpbGroup(),
-
-        # New OLMo 3
-        "sciq:bpb::olmo3",
-        "qasper_yesno:bpb::olmes",
-        "basic_skills:bpb::olmes",
-        "lab_bench_dbqa:bpb",
-        "lab_bench_protocolqa:bpb",
-        "lambada:bpb",
-        "medmcqa:bpb::none",
-        "medqa_en:bpb::none",
-        "sciriff_yesno:bpb::olmes",
-        "ultrachat_masked_ppl",
-        "wildchat_masked_ppl",
     ]
 
 @NamedTasksGroupRegistry.register("olmo3:dev:7b:math:v2")

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -284,6 +284,11 @@ class ARCMCGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{category}:mc::olmes" for category in constants.ARC_TASKS]
 
 
+@NamedTasksGroupRegistry.register("arc:bpb::full")
+class ARCBPBFullGroup(BaseAverageNamedTasksGroup):
+    tasks = [f"{category}:bpb::olmes:full" for category in constants.ARC_TASKS]
+
+
 @NamedTasksGroupRegistry.register("arc:rc::full")
 class ARCRCFullGroup(BaseAverageNamedTasksGroup):
     tasks = [f"{category}:rc::olmes:full" for category in constants.ARC_TASKS]
@@ -571,6 +576,38 @@ class Olmo3Dev1bCodeBpbGroup(BaseAverageOfAveragesNamedTasksGroup):
         "codex_humaneval:3shot:bpb::none",
         "mbpp:3shot:bpb::none",
         MtMbppV2fixGroup(),
+    ]
+
+
+@NamedTasksGroupRegistry.register("olmo3:dev:1b:qa:bpb")
+class Olmo3Dev1bQaBpbGroup(BaseAverageOfAveragesNamedTasksGroup):
+    tasks = [
+        # Core OLMES
+        ARCBPBFullGroup(),
+        MMLUBpbGroup(),
+        "csqa:bpb::olmes:full",
+        "hellaswag:bpb::olmes:full",
+        "winogrande:bpb::olmes:full",
+        "socialiqa:bpb::olmes:full",
+        "piqa:bpb::olmes:full",
+
+        # Gen OLMES
+        "coqa:bpb::gen2mc",
+        "drop:bpb::gen2mc",
+        "jeopardy:bpb::gen2mc",
+        "naturalqs:bpb::gen2mc",
+        "squad:bpb::gen2mc",
+
+        # New OLMo 3
+        "sciq:bpb::olmo3",
+        "qasper_yesno:bpb::olmes",
+        "basic_skills:bpb::olmes",
+        "lab_bench_dbqa:bpb",
+        "lab_bench_protocolqa:bpb",
+        "lambada:bpb",
+        "medmcqa:bpb::none",
+        "medqa_en:bpb::none",
+        "sciriff_yesno:bpb::olmes",
     ]
 
 

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -178,7 +178,6 @@ def make_results_from_dashboard(
     expanded_tasks = ExpandedTasks.from_tasks(tasks)
     expanded_models = ExpandedModels.from_models(models or [])
 
-
     # start by filtering in all the single tasks
     results = dashboard_table.keep_cols(*expanded_tasks.single_tasks)
 

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -178,8 +178,6 @@ def make_results_from_dashboard(
     expanded_tasks = ExpandedTasks.from_tasks(tasks)
     expanded_models = ExpandedModels.from_models(models or [])
 
-    from rich import print
-    print(expanded_tasks)
 
     # start by filtering in all the single tasks
     results = dashboard_table.keep_cols(*expanded_tasks.single_tasks)

--- a/src/cookbook/eval/results.py
+++ b/src/cookbook/eval/results.py
@@ -178,6 +178,9 @@ def make_results_from_dashboard(
     expanded_tasks = ExpandedTasks.from_tasks(tasks)
     expanded_models = ExpandedModels.from_models(models or [])
 
+    from rich import print
+    print(expanded_tasks)
+
     # start by filtering in all the single tasks
     results = dashboard_table.keep_cols(*expanded_tasks.single_tasks)
 


### PR DESCRIPTION
`olmo3:dev:1b:bpb` appears to not have been properly ported from the old task setup -> new task setup.

### view

```sh
olmo-cookbook-eval results -d olmo-3-baseline -t olmo3:dev:1b:bpb --skip-on-fail
```