### PR TITLE
add 1B main v2 group

### DIFF
--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -667,7 +667,7 @@ class Olmo3Dev1bQaBpbV2Group(BaseAverageOfAveragesNamedTasksGroup):
         "lambada:bpb",
         "medmcqa:bpb::none",
         "medqa_en:bpb::none",
-        # "sciriff_yesno:bpb::olmes",
+        "sciriff_yesno:bpb::olmes",
     ]
 
 

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -699,7 +699,7 @@ class Olmo3Dev1bQaRcGroup(BaseAverageOfAveragesNamedTasksGroup):
         "lambada",
         "medmcqa:rc::none",
         "medqa_en:rc::none",
-        # "sciriff_yesno:rc::olmes",
+        "sciriff_yesno:rc::olmes",
     ]
 
 
@@ -731,7 +731,7 @@ class Olmo3Dev1bQaRcV2Group(BaseAverageOfAveragesNamedTasksGroup):
         "lambada",
         "medmcqa:rc::none",
         "medqa_en:rc::none",
-        # "sciriff_yesno:rc::olmes",
+        "sciriff_yesno:rc::olmes",
     ]
 
 

--- a/src/cookbook/eval/named_tasks.py
+++ b/src/cookbook/eval/named_tasks.py
@@ -667,7 +667,7 @@ class Olmo3Dev1bQaBpbV2Group(BaseAverageOfAveragesNamedTasksGroup):
         "lambada:bpb",
         "medmcqa:bpb::none",
         "medqa_en:bpb::none",
-        "sciriff_yesno:bpb::olmes",
+        # "sciriff_yesno:bpb::olmes",
     ]
 
 
@@ -699,7 +699,7 @@ class Olmo3Dev1bQaRcGroup(BaseAverageOfAveragesNamedTasksGroup):
         "lambada",
         "medmcqa:rc::none",
         "medqa_en:rc::none",
-        "sciriff_yesno:rc::olmes",
+        # "sciriff_yesno:rc::olmes",
     ]
 
 
@@ -731,7 +731,7 @@ class Olmo3Dev1bQaRcV2Group(BaseAverageOfAveragesNamedTasksGroup):
         "lambada",
         "medmcqa:rc::none",
         "medqa_en:rc::none",
-        "sciriff_yesno:rc::olmes",
+        # "sciriff_yesno:rc::olmes",
     ]
 
 
@@ -924,6 +924,25 @@ class Olmo3Dev1bMainGroup(BaseNamedTasksWithNoAverageGroup):
         Olmo3Dev1bMathBpbGroup(),
         Olmo3Dev1bCodeBpbGroup(),
         Olmo3Dev1bQaRcGroup(),
+        ARCRCFullGroup(),
+        "hellaswag:rc::olmes:full",
+        BasicRCGroup(),
+        MtMbppV2fixGroup(),
+        MMLURCGroup(),
+        MMLUBpbGroup(),
+        "codex_humaneval:3shot:bpb::none",
+        "mbpp:3shot:bpb::none",
+        MinervaBpbGroup()
+    ]
+
+
+@NamedTasksGroupRegistry.register("olmo3:dev:1b:main:v2")
+class Olmo3Dev1bMainV2Group(BaseNamedTasksWithNoAverageGroup):
+    tasks = [
+        Olmo3Dev1bMathBpbGroup(),
+        Olmo3Dev1bCodeBpbGroup(),
+        Olmo3Dev1bQaBpbV2Group(),
+        Olmo3Dev1bQaRcV2Group(),
         ARCRCFullGroup(),
         "hellaswag:rc::olmes:full",
         BasicRCGroup(),


### PR DESCRIPTION
Add `olmo3:dev:1b:main:v2`. I realized we didn't have the parent task when I added the gen2mc BPB tasks, I only included it in `olmo3:paper` and in the large-scale config.